### PR TITLE
Fixed pagination for between tag

### DIFF
--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -63,7 +63,7 @@ class Events extends CollectionTag
             $this->offset = $this->params->int('offset', 0);
 
             $this->setOffsetForPagination();
-            $this->paginate($this->events->all($from, $to)->slice($this->offset, $this->limit));
+            $this->paginateBetween($this->events->all($from, $to));
 
             return $this->outputData();
         }
@@ -199,6 +199,38 @@ class Events extends CollectionTag
         ];
 
         $this->dates = $events->slice(0, $this->limit);
+    }
+
+    protected function paginateBetween(Collection $events): void
+    {
+        $this->paginated = true;
+
+        $page = (int) request('page', 1);
+
+        
+        $paginator = new LengthAwarePaginator(
+            items: $events,
+            total: $count = $events->count(),
+            perPage: $this->limit,
+            currentPage: $page
+        );
+
+        $paginator
+            ->setPath(URL::makeAbsolute(URL::getCurrent()))
+            ->appends(request()->all());
+
+        $this->paginationData = [
+            'total_items'    => $count,
+            'items_per_page' => $this->limit,
+            'total_pages'    => $paginator->lastPage(),
+            'current_page'   => $paginator->currentPage(),
+            'prev_page'      => $paginator->previousPageUrl(),
+            'next_page'      => $paginator->nextPageUrl(),
+            'auto_links'     => $paginator->render(),
+            'links'          => $paginator->render(),
+        ];
+
+        $this->dates = $events->slice($this->offset, $this->limit);
     }
 
     protected function outputData(): array


### PR DESCRIPTION
Fix for the pagination issue with the between tag.  Referenced here in this latest issue.  https://github.com/transformstudios/statamic-events-v3/issues/19

I basically just copied the paginate function and created a new one paginateBetween.  Really the only difference between these functions is the last line
```
        $this->dates = $events->slice($this->offset, $this->limit);
```

as well as passing all events into it:
```
            $this->paginateBetween($this->events->all($from, $to));
```

I tested this on a fresh install of Statamic with my events copied over.  Also made slight modifications to the documentation.  I replaced ```{{ date }}``` with ```{{ start_date }}``` because ```{{ date }}``` was incorrect and seemed to be giving me the last time the particular event was modified or accessed.