### PR TITLE
Remove Earliest Date from Fieldset

### DIFF
--- a/resources/fieldsets/event.yaml
+++ b/resources/fieldsets/event.yaml
@@ -125,7 +125,6 @@ fields:
       allow_blank: true
       allow_time: false
       require_time: false
-      earliest_date: 'January 1, 1900'
       input_format: M/D/YYYY
       display: 'End Date'
       width: 25


### PR DESCRIPTION
As per bug [https://github.com/statamic/cms/issues/4669](https://github.com/statamic/cms/issues/4669) the earliest_date causes Statamic to throw a Carbon error. Removing this fixes the issue.