### PR TITLE
Add the `id` due to Statamic runtime parser issue

### DIFF
--- a/src/Types/Event.php
+++ b/src/Types/Event.php
@@ -6,6 +6,7 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
+use Ramsey\Uuid\Uuid;
 use RRule\RRuleInterface;
 use Spatie\IcalendarGenerator\Components\Event as ICalendarEvent;
 use Statamic\Entries\Entry;
@@ -110,6 +111,7 @@ abstract class Event
     protected function supplement(CarbonInterface $date): ?Entry
     {
         return unserialize(serialize($this->event))
+            ->id(Uuid::uuid4()->toString())
             ->setSupplement('start', $date->setTimeFromTimeString($this->startTime()))
             ->setSupplement('end', $date->setTimeFromTimeString($this->endTime()))
             ->setSupplement('has_end_time', $this->hasEndTime());

--- a/src/Types/MultiDayEvent.php
+++ b/src/Types/MultiDayEvent.php
@@ -5,6 +5,7 @@ namespace TransformStudios\Events\Types;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
+use Ramsey\Uuid\Uuid;
 use RRule\RRule;
 use RRule\RRuleInterface;
 use RRule\RSet;
@@ -101,6 +102,7 @@ class MultiDayEvent extends Event
         return tap(
             unserialize(serialize($this->event)),
             fn (Entry $occurrence) => $occurrence
+                ->id(Uuid::uuid4()->toString())
                 ->setSupplement('collapse_multi_days', $occurrence->collapseMultiDays)
                 ->setSupplement('start', $day->start())
                 ->setSupplement('end', $day->end())


### PR DESCRIPTION
Due to https://github.com/statamic/cms/issues/7389, we have to give each occurrence its own unique `id`

Closes #49 