### PR TITLE
Don't set `id`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "rlanvin/php-rrule": "^2.3.1",
         "spatie/calendar-links": "1.*",
         "spatie/icalendar-generator": "^2.3.3",
-        "statamic/cms": "^3.3"
+        "statamic/cms": "^3.3.66"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",

--- a/src/Types/Event.php
+++ b/src/Types/Event.php
@@ -6,7 +6,6 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
-use Ramsey\Uuid\Uuid;
 use RRule\RRuleInterface;
 use Spatie\IcalendarGenerator\Components\Event as ICalendarEvent;
 use Statamic\Entries\Entry;
@@ -111,7 +110,6 @@ abstract class Event
     protected function supplement(CarbonInterface $date): ?Entry
     {
         return unserialize(serialize($this->event))
-            ->id(Uuid::uuid4()->toString())
             ->setSupplement('start', $date->setTimeFromTimeString($this->startTime()))
             ->setSupplement('end', $date->setTimeFromTimeString($this->endTime()))
             ->setSupplement('has_end_time', $this->hasEndTime());

--- a/src/Types/MultiDayEvent.php
+++ b/src/Types/MultiDayEvent.php
@@ -5,7 +5,6 @@ namespace TransformStudios\Events\Types;
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
-use Ramsey\Uuid\Uuid;
 use RRule\RRule;
 use RRule\RRuleInterface;
 use RRule\RSet;
@@ -102,7 +101,6 @@ class MultiDayEvent extends Event
         return tap(
             unserialize(serialize($this->event)),
             fn (Entry $occurrence) => $occurrence
-                ->id(Uuid::uuid4()->toString())
                 ->setSupplement('collapse_multi_days', $occurrence->collapseMultiDays)
                 ->setSupplement('start', $day->start())
                 ->setSupplement('end', $day->end())


### PR DESCRIPTION
Closes #52
Closes https://github.com/transformstudios/khalilcenter.com/issues/45

Can't have a random id, otherwise augmentation nor downloads work properly as there's no entry to augment/find.