### PR TITLE
Remove EntryQueryBuilder type declarations in Entry query

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -10,7 +10,6 @@ use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\Entry as EntryFacade;
 use Statamic\Facades\Site;
-use Statamic\Stache\Query\EntryQueryBuilder;
 use Statamic\Support\Arr;
 use Statamic\Tags\Concerns\QueriesConditions;
 
@@ -127,11 +126,11 @@ class Events
         $query = EntryFacade::query()
             ->when(
                 $this->event,
-                fn (EntryQueryBuilder $query, $id) => $query->where('id', $id),
-                fn (EntryQueryBuilder $query) => $query->where('collection', $this->collection)
+                fn ($query, $id) => $query->where('id', $id),
+                fn ($query) => $query->where('collection', $this->collection)
             )->where('site', $this->site ?? Site::current()->handle())
             ->where('status', 'published')
-            ->when($this->terms, fn (EntryQueryBuilder $query, $terms) => $query->whereTaxonomyIn($terms));
+            ->when($this->terms, fn ($query, $terms) => $query->whereTaxonomyIn($terms));
 
         collect($this->filters)->each(function ($value, $fieldCondition) use ($query) {
             [$field, $condition] = explode(':', $fieldCondition);


### PR DESCRIPTION
When using the Eloquent Driver I cannot use this package due to the type declarations.

```
TransformStudios\Events\Events::TransformStudios\Events\{closure}(): Argument #1 ($query) must be of type Statamic\Stache\Query\EntryQueryBuilder, Statamic\Eloquent\Entries\EntryQueryBuilder given, called in /var/www/html/vendor/statamic/cms/src/Query/EloquentQueryBuilder.php on line 357
```

Hopefully you're okay removing these? I can't see any of these type declarations throughout the Statamic CMS codebase where the `Entry` facade is being used...