### PR TITLE
Update Statamic version constraint for the Cascade class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "rlanvin/php-rrule": "^2.3.1",
         "spatie/calendar-links": "^1.0",
         "spatie/icalendar-generator": "^2.3.3",
-        "statamic/cms": "^4.1"
+        "statamic/cms": "^4.5"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",


### PR DESCRIPTION
Otherwise the "prefer-lowest" test fails.