### PR TITLE
Use first blueprint

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -9,6 +9,9 @@ Table Of Contents:
 ## Configuration
 
 If you'd like to have a different event timezone default than the app default (usually UTC), publish the config file (`php artisan vendor:publish --tag=events-config`), then update it via the CP. This is used on individual events that do not have a timezone set (see Fieldset below).
+
+The default collection for your events is `events`, if you use a different one, publish the config file (`php artisan vendor:publish --tag=events-config`) and set `collection` to the handle of your events collection.
+
 ## Fieldset
 
 In your collection's blueprint, make sure you have fields like in our sample [fieldset](https://github.com/transformstudios/statamic-events/blob/main/resources/fieldsets/event.yaml).

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -10,7 +10,7 @@ Table Of Contents:
 
 If you'd like to have a different event timezone default than the app default (usually UTC), publish the config file (`php artisan vendor:publish --tag=events-config`), then update it via the CP. This is used on individual events that do not have a timezone set (see Fieldset below).
 
-The default collection for your events is `events`, if you use a different one, publish the config file (`php artisan vendor:publish --tag=events-config`) and set `collection` to the handle of your events collection.
+The default collection for your events is `events`, if you use a different one, publish the config file and then update it via the CP.
 
 ## Fieldset
 

--- a/resources/blueprints/config.yaml
+++ b/resources/blueprints/config.yaml
@@ -8,7 +8,7 @@ collection:
   max_items: 1
   mode: select
   type: collections
-  display: 'Event Collection'
+  display: 'Events Collection'
   icon: collections
   localizable: false
   listable: hidden

--- a/resources/blueprints/config.yaml
+++ b/resources/blueprints/config.yaml
@@ -4,3 +4,15 @@ timezone:
   max_items: 1
   mode: typeahead
   default: UTC
+collection:
+  max_items: 1
+  mode: select
+  type: collections
+  display: 'Event Collection'
+  icon: collections
+  localizable: false
+  listable: hidden
+  instructions_position: above
+  visibility: visible
+  replicator_preview: true
+  hide_display: false

--- a/resources/fieldsets/event.yaml
+++ b/resources/fieldsets/event.yaml
@@ -57,7 +57,7 @@ fields:
       listable: hidden
       instructions_position: above
       mode: typeahead
-      width: 25
+      width: 50
   -
     handle: days
     field:

--- a/src/Exceptions/FieldNotFoundException.php
+++ b/src/Exceptions/FieldNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace TransformStudios\Events\Exceptions;
+
+use Exception;
+
+class FieldNotFoundException extends Exception
+{
+    public function __construct(private string $field)
+    {
+        parent::__construct("Field [{$field}] not found, please make sure you have a `timezone` field in your blueprint.");
+
+        $this->field = $field;
+    }
+}

--- a/src/Fieldtypes/Timezones.php
+++ b/src/Fieldtypes/Timezones.php
@@ -3,6 +3,7 @@
 namespace TransformStudios\Events\Fieldtypes;
 
 use Statamic\Fieldtypes\Relationship;
+use Statamic\Support\Arr;
 
 class Timezones extends Relationship
 {
@@ -24,6 +25,15 @@ class Timezones extends Relationship
     {
         return collect($this->timezones())
             ->map(fn (array $zone) => $this->toItemArray($zone['timezone']));
+    }
+
+    public function preProcess($data)
+    {
+        if (is_array($data)) {
+            return [Arr::get($data, 'timezone')];
+        }
+
+        return Arr::wrap($data);
     }
 
     protected function toItemArray($key)

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,10 +4,10 @@ namespace TransformStudios\Events;
 
 use Edalzell\Forma\Forma;
 use Illuminate\Support\Carbon;
-use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Providers\AddonServiceProvider;
+use Statamic\Support\Arr;
 use TransformStudios\Events\Fieldtypes\Timezones;
 use TransformStudios\Events\Modifiers\InMonth;
 use TransformStudios\Events\Modifiers\IsEndOfWeek;
@@ -73,7 +73,11 @@ class ServiceProvider extends AddonServiceProvider
 
             $timezone = config('events.timezone', config('app.timezone'));
 
-            return Blueprint::find('collections/events/event')
+            $collection = Collection::findByHandle(config('events.collection', 'events'));
+
+            $blueprint = Arr::first($collection->entryBlueprints());
+
+            return $blueprint
                 ->field('timezone')
                 ->setValue($timezone)
                 ->augment()

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Support\Arr;
+use TransformStudios\Events\Exceptions\FieldNotFoundException;
 use TransformStudios\Events\Fieldtypes\Timezones;
 use TransformStudios\Events\Modifiers\InMonth;
 use TransformStudios\Events\Modifiers\IsEndOfWeek;
@@ -77,8 +78,11 @@ class ServiceProvider extends AddonServiceProvider
 
             $blueprint = Arr::first($collection->entryBlueprints());
 
-            return $blueprint
-                ->field('timezone')
+            if (is_null($tzField = $blueprint->field('timezone'))) {
+                throw new FieldNotFoundException('timezone');
+            }
+
+            return $tzField
                 ->setValue($timezone)
                 ->augment()
                 ->value()


### PR DESCRIPTION
Now checks a config for the correct events collection, defaulting to `events` and the first blueprint in that collection.

Closes #69 