### PR TITLE
Add `preProcessIndex`

### DIFF
--- a/src/Fieldtypes/Timezones.php
+++ b/src/Fieldtypes/Timezones.php
@@ -36,6 +36,19 @@ class Timezones extends Relationship
         return Arr::wrap($data);
     }
 
+    public function preProcessIndex($key)
+    {
+        if (is_null($key)) {
+            return null;
+        }
+
+        if (is_null($augmented = $this->timezone($key))) {
+            return $key;
+        }
+
+        return $augmented['timezone'];
+    }
+
     protected function toItemArray($key)
     {
         if (is_null($key)) {


### PR DESCRIPTION
References https://github.com/transformstudios/khalilcenter.com/issues/131.

We need to add this method because when you pick entries in a Bard link picker, it needs to be able to display the timezone data in the listing (even if it's not in the columns).