### PR TITLE
Fix `end` timezone on recurring events that don't have an `end_time` set

### DIFF
--- a/src/Types/RecurringEvent.php
+++ b/src/Types/RecurringEvent.php
@@ -41,7 +41,7 @@ class RecurringEvent extends Event
         ];
 
         if ($end = $this->end_date) {
-            $rule['until'] = Carbon::parse($end)->endOfDay();
+            $rule['until'] = Carbon::parse($end)->shiftTimezone($this->timezone['timezone'])->endOfDay();
         }
 
         return new RRule($rule);

--- a/tests/Unit/RecurringEventsTest.php
+++ b/tests/Unit/RecurringEventsTest.php
@@ -43,4 +43,25 @@ class RecurringEventsTest extends TestCase
     //     $this->assertNull($event->endDate());
     //     $this->assertNull($event->end());
     // }
+
+    /** @test */
+    public function canShowLastOccurrenceWhenNoEndTime()
+    {
+        Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
+
+        $recurringEntry = tap(Entry::make()
+            ->collection('events')
+            ->data([
+                'start_date' => Carbon::now()->addDays(1)->toDateString(),
+                'start_time' => '22:00',
+                'recurrence' => 'daily',
+                'end_date' => Carbon::now()->addDays(2)->toDateString(),
+                'timezone' => 'America/Chicago',
+            ]))->save();
+
+        $occurrences = Events::fromCollection(handle: 'events')
+            ->between(Carbon::now(), Carbon::now()->addDays(5)->endOfDay());
+
+        $this->assertCount(2, $occurrences);
+    }
 }


### PR DESCRIPTION
Closes #81

To trigger this you need to have an event in a non-UTC timezone that's behind UTC by several hours and have no `end_time` set so that it defaults to the end of day.

Issue is that the end was being set to UTC which means the last occurrence was never shown because it was in the past.