### PR TITLE
Improve legacy data handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "nunomaduro/collision": "^6.0 || ^7.0",
         "phpunit/phpunit": "^9.0 || ^10.0",
         "orchestra/testbench": "^7.0 || ^8.0",
+        "spatie/laravel-ray": "^1.35",
         "spatie/test-time": "^1.2"
     },
     "config": {

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -17,7 +17,7 @@ class EventFactory
         }
 
         // this has to be `->value` because `recurrence` returns a `LabeledValue`.
-        if ($event->recurrence->value()) {
+        if (in_array($event->recurrence->value(), ['daily', 'weekly', 'monthly', 'every'])) {
             return new RecurringEvent($event);
         }
 

--- a/src/Events.php
+++ b/src/Events.php
@@ -3,6 +3,7 @@
 namespace TransformStudios\Events;
 
 use Carbon\CarbonInterface;
+use Exception;
 use Illuminate\Support\Traits\Conditionable;
 use Statamic\Entries\Entry;
 use Statamic\Entries\EntryCollection;
@@ -165,13 +166,27 @@ class Events
     private function occurrences(callable $generator): EntryCollection
     {
         return $this->entries
-            // take each event and generate the occurences
+            // take each event and generate the occurrences
+            ->filter(fn (Entry $occurrence) => $this->hasStartDate($occurrence))
             ->flatMap(callback: $generator)
             ->reject(fn (Entry $occurrence) => collect($occurrence->exclude_dates)
                 ->filter(fn (Values $dateRow) => $dateRow->date)
                 ->contains(fn (Values $dateRow) => $dateRow->date->isSameDay($occurrence->start))
             )->sortBy(callback: fn (Entry $occurrence) => $occurrence->start, descending: $this->sort === 'desc')
             ->values();
+    }
+
+    private function hasStartDate(Entry $occurrence): bool
+    {
+        if ($occurrence->multi_day || $occurrence->get('recurrence') === 'multi_day') {
+            try {
+                return collect($occurrence->days)->every(fn (Values $day) => $day->date);
+            } catch (Exception $e) {
+                return false;
+            }
+        }
+
+        return $occurrence->has('start_date');
     }
 
     private function paginate(EntryCollection $occurrences): LengthAwarePaginator

--- a/src/Events.php
+++ b/src/Events.php
@@ -166,8 +166,8 @@ class Events
     private function occurrences(callable $generator): EntryCollection
     {
         return $this->entries
-            // take each event and generate the occurrences
             ->filter(fn (Entry $occurrence) => $this->hasStartDate($occurrence))
+            // take each event and generate the occurrences
             ->flatMap(callback: $generator)
             ->reject(fn (Entry $occurrence) => collect($occurrence->exclude_dates)
                 ->filter(fn (Values $dateRow) => $dateRow->date)
@@ -180,7 +180,9 @@ class Events
     {
         if ($occurrence->multi_day || $occurrence->get('recurrence') === 'multi_day') {
             try {
-                return collect($occurrence->days)->every(fn (Values $day) => $day->date);
+                $days = collect($occurrence->days);
+
+                return $days->isNotEmpty() && $days->every(fn (Values $day) => $day->date);
             } catch (Exception $e) {
                 return false;
             }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -67,6 +67,14 @@ class ServiceProvider extends AddonServiceProvider
 
     private function bootFields(): self
     {
+        Collection::computed('events', 'recurrence', function ($entry, $value) {
+            if ($value) {
+                return $value;
+            }
+
+            return $entry->multi_day ? 'multi_day' : 'none';
+        });
+
         Collection::computed('events', 'timezone', function ($entry, $value) {
             if ($value) {
                 return $value;

--- a/tests/Unit/EventsTest.php
+++ b/tests/Unit/EventsTest.php
@@ -400,6 +400,13 @@ class EventsTest extends TestCase
                     ['date' => 'bad-date'],
                 ],
             ])->save();
+        Entry::make()
+            ->collection('events')
+            ->slug('legacy-multi-day-event-2')
+            ->data([
+                'title' => 'Legacy Multi-day Event',
+                'multi_day' => true,
+            ])->save();
 
         $occurrences = Events::fromCollection(handle: 'events')
             ->upcoming(5);

--- a/tests/Unit/EventsTest.php
+++ b/tests/Unit/EventsTest.php
@@ -376,4 +376,34 @@ class EventsTest extends TestCase
 
         $this->assertCount(4, $occurrences);
     }
+
+    /** @test */
+    public function canFilterOurEventsWithNoStartDate()
+    {
+        Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
+
+        Entry::make()
+            ->collection('events')
+            ->slug('single-event')
+            ->data([
+                'title' => 'Single Event',
+                'start_time' => '11:00',
+                'end_time' => '12:00',
+            ])->save();
+        Entry::make()
+            ->collection('events')
+            ->slug('legacy-multi-day-event')
+            ->data([
+                'title' => 'Legacy Multi-day Event',
+                'multi_day' => true,
+                'days' => [
+                    ['date' => 'bad-date'],
+                ],
+            ])->save();
+
+        $occurrences = Events::fromCollection(handle: 'events')
+            ->upcoming(5);
+
+        $this->assertEmpty($occurrences);
+    }
 }


### PR DESCRIPTION
References https://github.com/transformstudios/khalilcenter.com/issues/173.

Few things fixed:

* if you had a legacy multi-day event (using the old `multi_day` field) but no dates, there was an error thrown when the "end date" was retrieved
* if you had a legacy multi-day event the existing days were not shown in the entry
