### PR TITLE
Better handling of legacy multi-day events

### DIFF
--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -12,15 +12,21 @@ class EventFactory
 {
     public static function createFromEntry(Entry $event, bool $collapseMultiDays = false): Event
     {
-        if ($event->multi_day || $event->recurrence->value() === 'multi_day') {
-            return new MultiDayEvent($event, $collapseMultiDays);
+        $eventType = static::getTypeClass($event);
+
+        return new $eventType($event, $collapseMultiDays);
+    }
+
+    public static function getTypeClass(Entry $event): string
+    {
+        if (in_array($event->get('recurrence'), ['daily', 'weekly', 'monthly', 'every'])) {
+            return RecurringEvent::class;
         }
 
-        // this has to be `->value` because `recurrence` returns a `LabeledValue`.
-        if (in_array($event->recurrence->value(), ['daily', 'weekly', 'monthly', 'every'])) {
-            return new RecurringEvent($event);
+        if (($event->multi_day || $event->get('recurrence') === 'multi_day') && !empty($event->get('days'))) {
+            return MultiDayEvent::class;
         }
 
-        return new SingleDayEvent($event);
+        return SingleDayEvent::class;
     }
 }

--- a/src/Events.php
+++ b/src/Events.php
@@ -14,6 +14,7 @@ use Statamic\Facades\Site;
 use Statamic\Fields\Values;
 use Statamic\Support\Arr;
 use Statamic\Tags\Concerns\QueriesConditions;
+use TransformStudios\Events\Types\MultiDayEvent;
 
 class Events
 {
@@ -163,6 +164,11 @@ class Events
         return $this;
     }
 
+    private function isMultiDay(Entry $occurrence): bool
+    {
+        return EventFactory::getTypeClass(event: $occurrence) === MultiDayEvent::class;
+    }
+
     private function occurrences(callable $generator): EntryCollection
     {
         return $this->entries
@@ -178,7 +184,7 @@ class Events
 
     private function hasStartDate(Entry $occurrence): bool
     {
-        if ($occurrence->multi_day || $occurrence->get('recurrence') === 'multi_day') {
+        if ($this->isMultiDay($occurrence)) {
             try {
                 $days = collect($occurrence->days);
 

--- a/src/Types/Event.php
+++ b/src/Types/Event.php
@@ -41,7 +41,7 @@ abstract class Event
 
     public function isMultiDay(): bool
     {
-        return boolval($this->multi_day) || $this->recurrence?->value() === 'multi_day';
+        return boolval(($this->multi_day || $this->recurrence?->value() === 'multi_day') && ! empty($this->days));
     }
 
     public function isRecurring(): bool

--- a/tests/Unit/EventFactoryTest.php
+++ b/tests/Unit/EventFactoryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace TransformStudios\Events\Tests\Unit;
+
+use Illuminate\Support\Carbon;
+use Statamic\Facades\Entry;
+use TransformStudios\Events\EventFactory;
+use TransformStudios\Events\Tests\TestCase;
+use TransformStudios\Events\Types\MultiDayEvent;
+use TransformStudios\Events\Types\RecurringEvent;
+use TransformStudios\Events\Types\SingleDayEvent;
+
+class EventFactoryTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider provideEventData
+     */
+    public function canGetEventTypeClass(string $class, array $data)
+    {
+        $entry = Entry::make()
+            ->collection('events')
+            ->data($data);
+
+        $this->assertEquals($class, EventFactory::getTypeClass($entry));
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideEventData
+     */
+    public function canCreateCorrectEventType(string $class, array $data)
+    {
+        $entry = Entry::make()
+            ->collection('events')
+            ->data($data);
+
+        $this->assertInstanceOf($class, EventFactory::createFromEntry($entry));
+    }
+
+    public static function provideEventData()
+    {
+        return [
+            [
+                SingleDayEvent::class,
+                [
+                    'start_date' => Carbon::now()->toDateString(),
+                    'start_time' => '11:00',
+                    'end_time' => '12:00',
+                    'timezone' => 'America/Vancouver',
+                ],
+            ],
+            [
+                SingleDayEvent::class,
+                [
+                    'multi_day' => true,
+                    'start_date' => Carbon::now()->toDateString(),
+                    'start_time' => '11:00',
+                    'end_time' => '12:00',
+                    'timezone' => 'America/Vancouver',
+                ],
+            ],
+            [
+                RecurringEvent::class,
+                [
+                    'start_date' => Carbon::now()->toDateString(),
+                    'end_date' => Carbon::now()->addWeek()->toDateString(),
+                    'start_time' => '11:00',
+                    'end_time' => '12:00',
+                    'recurrence' => 'daily',
+                    'timezone' => 'America/Vancouver',
+                ],
+            ],
+            [
+                MultiDayEvent::class,
+                [
+                    'recurrence' => 'multi_day',
+                    'days' => [
+                        [
+                            'date' => '2019-11-23',
+                            'start_time' => '19:00',
+                            'end_time' => '21:00',
+                        ],
+                        [
+                            'date' => '2019-11-24',
+                            'start_time' => '11:00',
+                            'end_time' => '15:00',
+                        ],
+                    ],
+                    'timezone' => 'America/Vancouver',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/RecurringEventsTest.php
+++ b/tests/Unit/RecurringEventsTest.php
@@ -9,6 +9,7 @@ use TransformStudios\Events\Events;
 use TransformStudios\Events\Tests\TestCase;
 use TransformStudios\Events\Types\MultiDayEvent;
 use TransformStudios\Events\Types\RecurringEvent;
+use TransformStudios\Events\Types\SingleDayEvent;
 
 class RecurringEventsTest extends TestCase
 {
@@ -43,9 +44,9 @@ class RecurringEventsTest extends TestCase
 
         $event = EventFactory::createFromEntry($recurringEntry);
 
-        $this->assertTrue($event instanceof MultiDayEvent);
+        $this->assertTrue($event instanceof SingleDayEvent);
         $this->assertFalse($event->isRecurring());
-        $this->assertTrue($event->isMultiDay());
+        $this->assertFalse($event->isMultiDay());
     }
 
     /** @test */


### PR DESCRIPTION
If a legacy event that was multi-date is converted to a non-multi-day event, the `multi_day` field sticks around and caused missing occurrences.

Now we properly detect the correct event type.

References https://github.com/transformstudios/khalilcenter.com/issues/176