### PR TITLE
Explicitly set `multi_day`

### DIFF
--- a/src/Types/Event.php
+++ b/src/Types/Event.php
@@ -123,6 +123,7 @@ abstract class Event
     protected function supplement(CarbonInterface $date): ?Entry
     {
         return unserialize(serialize($this->event))
+            ->setSupplement('multi_day', true)
             ->setSupplement('start', $date->setTimeFromTimeString($this->startTime()))
             ->setSupplement('end', $date->setTimeFromTimeString($this->endTime()))
             ->setSupplement('has_end_time', $this->hasEndTime());

--- a/src/Types/MultiDayEvent.php
+++ b/src/Types/MultiDayEvent.php
@@ -105,6 +105,7 @@ class MultiDayEvent extends Event
             return tap(
                 unserialize(serialize($this->event)),
                 fn (Entry $occurrence) => $occurrence
+                    ->setSupplement('multi_day', true)
                     ->setSupplement('collapse_multi_days', true)
                     ->setSupplement('start', $this->start())
                     ->setSupplement('end', $this->end())
@@ -116,6 +117,7 @@ class MultiDayEvent extends Event
             unserialize(serialize($this->event)),
             fn (Entry $occurrence) => $occurrence
                 ->setSupplement('all_day', $day->isAllDay())
+                ->setSupplement('multi_day', true)
                 ->setSupplement('collapse_multi_days', $this->collapseMultiDays)
                 ->setSupplement('start', $day->start())
                 ->setSupplement('end', $day->end())


### PR DESCRIPTION
Otherwise legacy events that were previous multi-day but aren't now, still have `multi_day` set in their data.

References: https://github.com/transformstudios/khalilcenter.com/issues/176