### PR TITLE
Update Status Filter

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -150,7 +150,7 @@ class Events
                 fn ($query, $id) => $query->where('id', $id),
                 fn ($query) => $query->where('collection', $this->collection)
             )->where('site', $this->site ?? Site::current()->handle())
-            ->where('status', 'published')
+            ->whereStatus('published')
             ->when($this->terms, fn ($query, $terms) => $query->whereTaxonomyIn($terms));
 
         collect($this->filters)->each(function ($value, $fieldCondition) use ($query) {


### PR DESCRIPTION
Change the main `entries()` method to use the new `whereStatus` query builder method available in [Statamic 5](https://statamic.dev/upgrade-guide/4-to-5#entries-may-now-only-be-queried-by-a-single-status).

Closes #96 