### PR TITLE
Remove legacy `recurrence` computed field

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -75,14 +75,6 @@ class ServiceProvider extends AddonServiceProvider
     {
         $collectionHandle = config('events.collection', 'events');
 
-        Collection::computed($collectionHandle, 'recurrence', function ($entry, $value) {
-            if ($value) {
-                return $value;
-            }
-
-            return $entry->multi_day ? 'multi_day' : 'none';
-        });
-
         Collection::computed($collectionHandle, 'timezone', function ($entry, $value) use ($collectionHandle) {
             if ($value) {
                 return $value;


### PR DESCRIPTION
This code, for some reason, prevents new Events from being created on our sites. There's also not much value in this code anymore as with the new "default" value behaviour in Statamic there's always a `recurrence` value (of `none`).

If you still need this, you'll have to manually make sure any event that had `multi_days: true` have `recurrence: 'multi-day'` instead.