### PR TITLE
Restrict to Carbon v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "php": "^8.2",
         "edalzell/forma": "^2.0 || ^3.0",
         "laravel/framework": "^9.6 || ^10.11 || ^11.0",
+        "nesbot/carbon": "^2.0",
         "rlanvin/php-rrule": "^2.3.1",
         "spatie/calendar-links": "^1.0",
         "spatie/icalendar-generator": "^2.3.3",


### PR DESCRIPTION
Statamic 5 supports carbon 3, but we don’t, yet