### PR TITLE
Make sure multi-day event days are in order

### DIFF
--- a/src/Types/MultiDayEvent.php
+++ b/src/Types/MultiDayEvent.php
@@ -22,6 +22,7 @@ class MultiDayEvent extends Event
         parent::__construct($event);
 
         $this->days = collect($this->event->days)
+            ->sortBy('date')
             ->map(fn (Values $day) => new Day(
                 $day->all(),
                 $this->timezone['timezone'],

--- a/tests/Unit/MultiDayEventsTest.php
+++ b/tests/Unit/MultiDayEventsTest.php
@@ -33,11 +33,6 @@ class MultiDayEventsTest extends TestCase
                 'recurrence' => 'multi_day',
                 'days' => [
                     [
-                        'date' => '2019-11-23',
-                        'start_time' => '19:00',
-                        'end_time' => '21:00',
-                    ],
-                    [
                         'date' => '2019-11-24',
                         'start_time' => '11:00',
                         'end_time' => '15:00',
@@ -46,6 +41,11 @@ class MultiDayEventsTest extends TestCase
                         'date' => '2019-11-25',
                         'start_time' => '11:00',
                         'end_time' => '15:00',
+                    ],
+                    [
+                        'date' => '2019-11-23',
+                        'start_time' => '19:00',
+                        'end_time' => '21:00',
                     ],
                 ],
                 'timezone' => 'America/Vancouver',

--- a/tests/Unit/MultiDayEventsTest.php
+++ b/tests/Unit/MultiDayEventsTest.php
@@ -119,6 +119,23 @@ class MultiDayEventsTest extends TestCase
     }
 
     #[Test]
+    public function canGetEnd()
+    {
+        $this->assertEquals(
+            Carbon::parse('2019-11-25 15:00')->shiftTimezone('America/Vancouver'),
+            $this->event->end()
+        );
+        $this->assertEquals(
+            Carbon::parse('2019-11-21 23:59:59.999999')->shiftTimezone('America/Vancouver'),
+            $this->allDayEvent->end()
+        );
+        $this->assertEquals(
+            Carbon::parse('2019-11-21 23:59:00')->shiftTimezone('America/Vancouver')->timezone,
+            $this->event->end()->timezone
+        );
+    }
+
+    #[Test]
     public function noOccurrencesIfNowAfterEndDate()
     {
         Carbon::setTestNow('2019-11-26');


### PR DESCRIPTION
References https://github.com/transformstudios/khalilcenter.com/issues/271

Multi-day events was built with the assumption that the days would be entered in order, but clients aren't doing that.

This sorts the days properly.