### PR TITLE
fix: events:between missing limit param

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -145,7 +145,7 @@ class Events
         return $this;
     }
 
-    public function between(string|CarbonInterface $from, string|CarbonInterface $to): EntryCollection|LengthAwarePaginator
+    public function between(string|CarbonInterface $from, string|CarbonInterface $to, int $limit = null): EntryCollection|LengthAwarePaginator
     {
         return $this->output(
             type: fn (Entry $entry) => EventFactory::createFromEntry(event: $entry, collapseMultiDays: $this->collapseMultiDays)->occurrencesBetween(from: $from, to: $to)

--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -24,10 +24,12 @@ class Events extends Tags
 
     public function between(): EntryCollection|array
     {
-        return $this->output($this->generator()->between(
+        $occurrences = $this->generator()->between(
             from: CarbonImmutable::parse($this->params->get('from', now()))->startOfDay(),
-            to: CarbonImmutable::parse($this->params->get('to'))->endOfDay()
-        ));
+            to: CarbonImmutable::parse($this->params->get('to'))->endOfDay(),
+            limit: $this->params->int('limit')
+        );
+        return $this->output($occurrences);
     }
 
     public function calendar(): Collection

--- a/src/Types/Event.php
+++ b/src/Types/Event.php
@@ -62,9 +62,9 @@ abstract class Event
         };
     }
 
-    public function occurrencesBetween(string|CarbonInterface $from, string|CarbonInterface $to): Collection
+    public function occurrencesBetween(string|CarbonInterface $from, string|CarbonInterface $to, int $limit = null): Collection
     {
-        return $this->collect($this->rule()->getOccurrencesBetween(begin: $from, end: $to));
+        return $this->collect($this->rule()->getOccurrencesBetween(begin: $from, end: $to, limit: $limit));
     }
 
     public function occursOnDate(string|CarbonInterface $date): bool


### PR DESCRIPTION
The `events:between` was missing the limit support. 