### PR TITLE
Use `booted` closure for missing timezone field

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,8 +2,12 @@
 
 namespace TransformStudios\Events;
 
+use Statamic\Entries\Entry;
 use Statamic\Facades\Collection;
-use Statamic\Facades\Field;
+use Statamic\Facades\Field as FieldFacade;
+use Statamic\Fields\Field;
+use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Dictionary;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
@@ -11,19 +15,29 @@ class ServiceProvider extends AddonServiceProvider
 {
     public function bootAddon()
     {
-        Field::computedDefault('default-events-timezone', fn () => Statamic::displayTimezone());
-        Field::computedDefault('default-event-timezone', fn () => Events::defaultTimezone());
+        FieldFacade::computedDefault('default-events-timezone', fn () => Statamic::displayTimezone());
+        FieldFacade::computedDefault('default-event-timezone', fn () => Events::defaultTimezone());
 
         collect(Events::setting('collections', ['events']))
-            ->each(function (string $collection) {
-                Collection::findByHandle($collection)?->entryBlueprint()->ensureField(
-                    'timezone',
-                    [
-                        'dictionary' => 'timezones',
-                        'max_items' => '1',
-                        'type' => 'dictionary',
-                        'default' => 'computed:default-event-timezone',
-                    ]);
-            });
+            ->each(fn (string $collection) => Collection::computed(
+                $collection,
+                'timezone',
+                $this->timezone(...)
+            ));
+    }
+
+    private function timezone(Entry $entry, $value): string|Value
+    {
+        $value ??= Events::defaultTimezone();
+
+        if ($entry->blueprint()->fields()->get('timezone')?->fieldtype() instanceof Dictionary) {
+            return $value;
+        }
+
+        return (new Field('timezone', ['type' => 'timezones', 'max_items' => 1]))
+            ->setValue($value)
+            ->setParent($entry)
+            ->augment()
+            ->value();
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,12 +2,8 @@
 
 namespace TransformStudios\Events;
 
-use Statamic\Entries\Entry;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Field as FieldFacade;
-use Statamic\Fields\Field;
-use Statamic\Fields\Value;
-use Statamic\Fieldtypes\Dictionary;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
@@ -18,26 +14,19 @@ class ServiceProvider extends AddonServiceProvider
         FieldFacade::computedDefault('default-events-timezone', fn () => Statamic::displayTimezone());
         FieldFacade::computedDefault('default-event-timezone', fn () => Events::defaultTimezone());
 
-        collect(Events::setting('collections', ['events']))
-            ->each(fn (string $collection) => Collection::computed(
-                $collection,
-                'timezone',
-                $this->timezone(...)
-            ));
-    }
-
-    private function timezone(Entry $entry, $value): string|Value
-    {
-        $value ??= Events::defaultTimezone();
-
-        if ($entry->blueprint()->fields()->get('timezone')?->fieldtype() instanceof Dictionary) {
-            return $value;
-        }
-
-        return (new Field('timezone', ['dictionary' => 'timezones', 'max_items' => '1', 'type' => 'dictionary']))
-            ->setValue($value)
-            ->setParent($entry)
-            ->augment()
-            ->value();
+        // has to be in booted so that the `events::event` fieldset is properly registered and loaded
+        $this->booted(function () {
+            collect(Events::setting('collections', ['events']))
+                ->each(function (string $collection) {
+                    Collection::findByHandle($collection)?->entryBlueprint()->ensureField(
+                        'timezone',
+                        [
+                            'dictionary' => 'timezones',
+                            'max_items' => '1',
+                            'type' => 'dictionary',
+                            'default' => 'computed:default-event-timezone',
+                        ]);
+                });
+        });
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,7 +3,7 @@
 namespace TransformStudios\Events;
 
 use Statamic\Facades\Collection;
-use Statamic\Facades\Field as FieldFacade;
+use Statamic\Facades\Field;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
@@ -11,8 +11,8 @@ class ServiceProvider extends AddonServiceProvider
 {
     public function bootAddon()
     {
-        FieldFacade::computedDefault('default-events-timezone', fn () => Statamic::displayTimezone());
-        FieldFacade::computedDefault('default-event-timezone', fn () => Events::defaultTimezone());
+        Field::computedDefault('default-events-timezone', fn () => Statamic::displayTimezone());
+        Field::computedDefault('default-event-timezone', fn () => Events::defaultTimezone());
 
         // has to be in booted so that the `events::event` fieldset is properly registered and loaded
         $this->booted(function () {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,7 +34,7 @@ class ServiceProvider extends AddonServiceProvider
             return $value;
         }
 
-        return (new Field('timezone', ['type' => 'timezones', 'max_items' => 1]))
+        return (new Field('timezone', ['dictionary' => 'timezones', 'max_items' => '1', 'type' => 'dictionary']))
             ->setValue($value)
             ->setParent($entry)
             ->augment()


### PR DESCRIPTION
Can't use `ensureField` because the addon isn't fully booted and the `events::event` fieldset isn't available.