### PR TITLE
Rename and snake case `spansDay` to `spans_days`

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -175,7 +175,7 @@ class Events
                 return $occurrence
                     ->setSupplement('start', $start)
                     ->setSupplement('end', $end)
-                    ->setSupplement('spansDay', ! $start->isSameDay($end));
+                    ->setSupplement('spans_days', ! $start->isSameDay($end));
             });
         }
 

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -428,7 +428,7 @@ it('uses the timezone param when generating occurrences', function () {
         ->first()->start->timezone->getName()->toBe('America/Vancouver');
 });
 
-it('sets "spansDay"', function () {
+it('sets "spans_days"', function () {
     Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
 
     Entry::make()
@@ -454,5 +454,5 @@ it('sets "spansDay"', function () {
     $occurrences = $this->tag->between();
 
     expect($occurrences)->toHaveCount(1)
-        ->first()->spansDay->toBeTrue();
+        ->first()->spanning_days->toBeTrue();
 });

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -454,5 +454,5 @@ it('sets "spans_days"', function () {
     $occurrences = $this->tag->between();
 
     expect($occurrences)->toHaveCount(1)
-        ->first()->spanning_days->toBeTrue();
+        ->first()->spans_days->toBeTrue();
 });


### PR DESCRIPTION
This PR renames the newly added `spansDay` supplement to a snake-cased `spans_days`, so it's more streamlined in Antlers.