### PR TITLE
Cleanup timezone handling and groupBy logic

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -174,7 +174,7 @@ class Events
                 return $occurrence
                     ->setSupplement('start', $start)
                     ->setSupplement('end', $end)
-                    ->setSupplement('spans_days', ! $start->isSameDay($end));
+                    ->setSupplement('spanning', ! $start->isSameDay($end));
             });
         }
 

--- a/src/Events.php
+++ b/src/Events.php
@@ -48,7 +48,6 @@ class Events
 
     public static function defaultTimezone(): string
     {
-        // return static::setting('timezone', config('statamic.system.display_timezone') ?? config('app.timezone', 'UTC'));
         return static::setting('timezone');
     }
 

--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -194,7 +194,7 @@ class Events extends Tags
                 value: $this->params->bool('collapse_multi_days'),
                 callback: fn (Generator $generator) => $generator->collapseMultiDays()
             )->when(
-                value: $this->params->get('timezone'),
+                value: $this->params->get('timezone', Generator::defaultTimezone()),
                 callback: fn (Generator $generator, string $tz) => $generator->timezone(timezone: $tz)
             );
     }

--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -47,16 +47,7 @@ class Events extends Tags
         $occurrences = $this
             ->generator()
             ->between(from: $from, to: $to)
-            ->groupBy(function (Entry $occurrence) {
-                $periodInTimezone = CarbonPeriodImmutable::between(
-                    $occurrence->start->setTimezone($this->params->get('timezone') ?? Generator::defaultTimezone())->startOfDay(),
-                    $occurrence->end->setTimezone($this->params->get('timezone') ?? Generator::defaultTimezone())->endOfDay()
-                );
-
-                return collect($periodInTimezone->toArray())
-                    ->map(fn (CarbonImmutable $date) => $date->toDateString())
-                    ->all();
-            })
+            ->groupBy($this->spanningDays())
             ->map(fn(EntryCollection $occurrences, string $date) => $this->day(date: $date, occurrences: $occurrences));
 
         $days = $this->output($this->makeEmptyDates(from: $from, to: $to)->merge($occurrences)->values());
@@ -251,5 +242,17 @@ class Events extends Tags
         return collect($this->explodeTerms($terms))
             ->map(fn (Term|string $term) => $this->getTermId(handle: $handle, term: $term))
             ->all();
+    }
+
+    private function spanningDays(): \Closure
+    {
+        return function (Entry $occurrence) {
+            $spanningDays = CarbonPeriodImmutable::between(
+                $occurrence->start->startOfDay(),
+                $occurrence->end->endOfDay()
+            )->toArray();
+
+            return collect($spanningDays)->map(fn(CarbonImmutable $date) => $date->toDateString())->all();
+        };
     }
 }

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -428,7 +428,7 @@ it('uses the timezone param when generating occurrences', function () {
         ->first()->start->timezone->getName()->toBe('America/Vancouver');
 });
 
-it('sets "spans_days"', function () {
+it('sets "spanning"', function () {
     Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
 
     Entry::make()
@@ -454,5 +454,5 @@ it('sets "spans_days"', function () {
     $occurrences = $this->tag->between();
 
     expect($occurrences)->toHaveCount(1)
-        ->first()->spans_days->toBeTrue();
+        ->first()->spanning->toBeTrue();
 });


### PR DESCRIPTION
This PR removes unnecessary timezone handling, renames `spans_days` to `spanning`, and tucks away the groupBy logic into a helper method.