### PR TITLE
Add `spanning_start` and `spanning_end`

### DIFF
--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -141,14 +141,16 @@ class Events extends Tags
         return [
             'date' => $date,
             'occurrences' => $occurrences->map(function (Entry $occurrence) use ($date): Entry {
-                if ($occurrence->spanning) {
-                    $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
-                    $occurrence
-                        ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
-                        ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
+                if (!$occurrence->spanning) {
+                    return $occurrence;
                 }
 
-                return $occurrence;
+                $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
+                $occurrence
+                    ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
+                    ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
+
+                return clone $occurrence;
             })->values(),
         ];
     }

--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -7,6 +7,7 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Carbon\CarbonPeriod;
 use Carbon\CarbonPeriodImmutable;
+use Closure;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Query\Builder;
@@ -41,14 +42,14 @@ class Events extends Tags
         $month = $this->params->get('month', now()->englishMonth);
         $year = $this->params->get('year', now()->year);
 
-        $from = parse_date($month . ' ' . $year)->startOfMonth()->startOfWeek();
-        $to = parse_date($month . ' ' . $year)->endOfMonth()->endOfWeek();
+        $from = parse_date($month.' '.$year)->startOfMonth()->startOfWeek();
+        $to = parse_date($month.' '.$year)->endOfMonth()->endOfWeek();
 
         $occurrences = $this
             ->generator()
             ->between(from: $from, to: $to)
             ->groupBy($this->spanningDays())
-            ->map(fn(EntryCollection $occurrences, string $date) => $this->day(date: $date, occurrences: $occurrences));
+            ->map(fn (EntryCollection $occurrences, string $date) => $this->day(date: $date, occurrences: $occurrences));
 
         $days = $this->output($this->makeEmptyDates(from: $from, to: $to)->merge($occurrences)->values());
 
@@ -139,8 +140,16 @@ class Events extends Tags
     {
         return [
             'date' => $date,
-            'dates' => $occurrences,
-            'occurrences' => $occurrences,
+            'occurrences' => $occurrences->map(function (Entry $occurrence) use ($date): Entry {
+                if ($occurrence->spanning) {
+                    $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
+                    $occurrence
+                        ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
+                        ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
+                }
+
+                return $occurrence;
+            })->values(),
         ];
     }
 
@@ -244,7 +253,7 @@ class Events extends Tags
             ->all();
     }
 
-    private function spanningDays(): \Closure
+    private function spanningDays(): Closure
     {
         return function (Entry $occurrence) {
             $spanningDays = CarbonPeriodImmutable::between(
@@ -252,7 +261,7 @@ class Events extends Tags
                 $occurrence->end->endOfDay()
             )->toArray();
 
-            return collect($spanningDays)->map(fn(CarbonImmutable $date) => $date->toDateString())->all();
+            return collect($spanningDays)->map(fn (CarbonImmutable $date) => $date->toDateString())->all();
         };
     }
 }

--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -138,20 +138,23 @@ class Events extends Tags
 
     private function day(string $date, EntryCollection $occurrences): array
     {
+        $occurrences = $occurrences->map(function (Entry $occurrence) use ($date): Entry {
+            if (!$occurrence->spanning) {
+                return $occurrence;
+            }
+
+            $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
+            $occurrence
+                ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
+                ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
+
+            return clone $occurrence;
+        })->values();
+
         return [
             'date' => $date,
-            'occurrences' => $occurrences->map(function (Entry $occurrence) use ($date): Entry {
-                if (!$occurrence->spanning) {
-                    return $occurrence;
-                }
-
-                $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
-                $occurrence
-                    ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
-                    ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
-
-                return clone $occurrence;
-            })->values(),
+            'dates'=> $occurrences,
+            'occurrences' => $occurrences,
         ];
     }
 

--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -42,14 +42,14 @@ class Events extends Tags
         $month = $this->params->get('month', now()->englishMonth);
         $year = $this->params->get('year', now()->year);
 
-        $from = parse_date($month . ' ' . $year)->startOfMonth()->startOfWeek();
-        $to = parse_date($month . ' ' . $year)->endOfMonth()->endOfWeek();
+        $from = parse_date($month.' '.$year)->startOfMonth()->startOfWeek();
+        $to = parse_date($month.' '.$year)->endOfMonth()->endOfWeek();
 
         $occurrences = $this
             ->generator()
             ->between(from: $from, to: $to)
             ->groupBy($this->spanningDays())
-            ->map(fn(EntryCollection $occurrences, string $date) => $this->day(date: $date, occurrences: $occurrences));
+            ->map(fn (EntryCollection $occurrences, string $date) => $this->day(date: $date, occurrences: $occurrences));
 
         $days = $this->output($this->makeEmptyDates(from: $from, to: $to)->merge($occurrences)->values());
 
@@ -136,22 +136,27 @@ class Events extends Tags
         return $this->output($occurrences->take($limit));
     }
 
+    private function addSpanningStartEnd(string $date, EntryCollection $occurrences): EntryCollection
+    {
+        return $occurrences->map(function (Entry $occurrence) use ($date) {
+            if (! $occurrence->spanning) {
+                return $occurrence;
+            }
+
+            $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
+            $occurrence
+                ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
+                ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
+
+            return clone $occurrence;
+        });
+    }
+
     private function day(string $date, EntryCollection $occurrences): array
     {
         return [
             'date' => $date,
-            'occurrences' => $occurrences->map(function (Entry $occurrence) use ($date): Entry {
-                if (!$occurrence->spanning) {
-                    return $occurrence;
-                }
-
-                $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
-                $occurrence
-                    ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
-                    ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
-
-                return clone $occurrence;
-            })->values(),
+            'occurrences' => $this->addSpanningStartEnd($date, $occurrences),
         ];
     }
 
@@ -263,7 +268,7 @@ class Events extends Tags
                 $occurrence->end->endOfDay()
             )->toArray();
 
-            return collect($spanningDays)->map(fn(CarbonImmutable $date) => $date->toDateString())->all();
+            return collect($spanningDays)->map(fn (CarbonImmutable $date) => $date->toDateString())->all();
         };
     }
 }

--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -138,23 +138,20 @@ class Events extends Tags
 
     private function day(string $date, EntryCollection $occurrences): array
     {
-        $occurrences = $occurrences->map(function (Entry $occurrence) use ($date): Entry {
-            if (!$occurrence->spanning) {
-                return $occurrence;
-            }
-
-            $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
-            $occurrence
-                ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
-                ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
-
-            return clone $occurrence;
-        })->values();
-
         return [
             'date' => $date,
-            'dates' => $occurrences,
-            'occurrences' => $occurrences,
+            'occurrences' => $occurrences->map(function (Entry $occurrence) use ($date): Entry {
+                if (!$occurrence->spanning) {
+                    return $occurrence;
+                }
+
+                $carbonDate = Carbon::parse($date)->shiftTimezone($occurrence->start->timezone);
+                $occurrence
+                    ->setSupplement('spanning_start', $occurrence->start->isSameDay($carbonDate))
+                    ->setSupplement('spanning_end', $occurrence->end->isSameDay($carbonDate));
+
+                return clone $occurrence;
+            })->values(),
         ];
     }
 

--- a/src/Tags/Events.php
+++ b/src/Tags/Events.php
@@ -42,14 +42,14 @@ class Events extends Tags
         $month = $this->params->get('month', now()->englishMonth);
         $year = $this->params->get('year', now()->year);
 
-        $from = parse_date($month.' '.$year)->startOfMonth()->startOfWeek();
-        $to = parse_date($month.' '.$year)->endOfMonth()->endOfWeek();
+        $from = parse_date($month . ' ' . $year)->startOfMonth()->startOfWeek();
+        $to = parse_date($month . ' ' . $year)->endOfMonth()->endOfWeek();
 
         $occurrences = $this
             ->generator()
             ->between(from: $from, to: $to)
             ->groupBy($this->spanningDays())
-            ->map(fn (EntryCollection $occurrences, string $date) => $this->day(date: $date, occurrences: $occurrences));
+            ->map(fn(EntryCollection $occurrences, string $date) => $this->day(date: $date, occurrences: $occurrences));
 
         $days = $this->output($this->makeEmptyDates(from: $from, to: $to)->merge($occurrences)->values());
 
@@ -153,7 +153,7 @@ class Events extends Tags
 
         return [
             'date' => $date,
-            'dates'=> $occurrences,
+            'dates' => $occurrences,
             'occurrences' => $occurrences,
         ];
     }
@@ -266,7 +266,7 @@ class Events extends Tags
                 $occurrence->end->endOfDay()
             )->toArray();
 
-            return collect($spanningDays)->map(fn (CarbonImmutable $date) => $date->toDateString())->all();
+            return collect($spanningDays)->map(fn(CarbonImmutable $date) => $date->toDateString())->all();
         };
     }
 }

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -456,3 +456,34 @@ it('sets "spanning"', function () {
     expect($occurrences)->toHaveCount(1)
         ->first()->spanning->toBeTrue();
 });
+
+it('sets "spanning-start" and "spanning-end"', function () {
+    Carbon::setTestNow(Carbon::parse('April 16 10:00am'));
+
+    Entry::make()
+        ->collection('events')
+        ->slug('single-event')
+        ->id('single-event')
+        ->data([
+            'title' => 'Event',
+            'start_date' => Carbon::now()->toDateString(),
+            'start_time' => '11:00',
+            'end_time' => '23:00',
+        ])->save();
+
+    $this->tag
+        ->setContext([])
+        ->setParameters(['timezone' => 'Europe/Kyiv']);
+
+    $days = $this->tag->calendar();
+    $firstSpanningOccurrence = $days[17]['occurrences'][1];
+    $secondSpanningOccurrence = $days[18]['occurrences'][0];
+
+    ray($days, $firstSpanningOccurrence);
+    expect($firstSpanningOccurrence)
+        ->spanning_start->toBeTrue()
+        ->spanning_end->toBeFalse();
+    // expect($secondSpanningOccurrence)
+    //     ->spanning_start->toBeFalse()
+    //     ->spanning_end->toBeTrue();
+});

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -476,14 +476,14 @@ it('sets "spanning-start" and "spanning-end"', function () {
         ->setParameters(['timezone' => 'Europe/Kyiv']);
 
     $days = $this->tag->calendar();
-    $firstSpanningOccurrence = $days[17]['occurrences'][1];
+    $firstSpanningOccurrence = $days[17]['occurrences'][0];
     $secondSpanningOccurrence = $days[18]['occurrences'][0];
 
-    ray($days, $firstSpanningOccurrence);
     expect($firstSpanningOccurrence)
         ->spanning_start->toBeTrue()
         ->spanning_end->toBeFalse();
-    // expect($secondSpanningOccurrence)
-    //     ->spanning_start->toBeFalse()
-    //     ->spanning_end->toBeTrue();
+
+     expect($secondSpanningOccurrence)
+         ->spanning_start->toBeFalse()
+         ->spanning_end->toBeTrue();
 });

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -96,7 +96,7 @@ test('can generate calendar occurrences', function () {
     $occurrences = $this->tag->calendar();
 
     expect($occurrences)->toHaveCount(42);
-    expect(Arr::get($occurrences, '5.dates'))->toHaveCount(2);
+    expect(Arr::get($occurrences, '5.occurrences'))->toHaveCount(2);
     expect(Arr::get($occurrences, '6.no_results'))->toBeTrue();
 });
 


### PR DESCRIPTION
This PR adds `spanning_start` and `spanning_end` to the supplements data. Additionally, it removes the legacy `dates` key from the calendar return values (they were the same as `occurrences`).