### PR TITLE
Update test matrix for Statamic v6

### DIFF
--- a/.github/workflows/gh-action-updater.yml
+++ b/.github/workflows/gh-action-updater.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Version Updater
+
+# Controls when the action will run.
+on:
+  schedule:
+    # Automatically run first day of every month
+    - cron:  '0 0 1 * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.WORKFLOW_SECRET }}
+
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.9.0
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [8.3, 8.4]
+        php: [8.3, 8.4, 8.5]
         laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*, 13.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         dependency-version: [prefer-stable]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         php: [8.3, 8.4]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         dependency-version: [prefer-stable]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
             path: ~/.composer/cache/files
             key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}


### PR DESCRIPTION
The addon currently only supports Statamic v6, which requires at least Laravel 12.

This PR:
- Removes Laravel 11 from the test matrix
- Adds Laravel 13 to the test matrix
- Adds PHP 8.5 to the test matrix
- Updates the used GitHub Actions to get rid of such warnings: 
`Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected`
