### PR TITLE
Fix ICS location data

### DIFF
--- a/src/Types/Event.php
+++ b/src/Types/Event.php
@@ -112,7 +112,7 @@ abstract class Event
             ->startsAt($immutableDate->setTimeFromTimeString($this->startTime()))
             ->endsAt($immutableDate->setTimeFromTimeString($this->endTime()));
 
-        if (! is_null($address = $this->event->address ?? $this->event->location)) {
+        if (! is_null($address = $this->event->address ?? $this->event->get('location'))) {
             $iCalEvent->address($address);
         }
 


### PR DESCRIPTION
If you had a custom `location` field on field that augmented to a `Values` object the ICS download feature was broken.