### PR TITLE
Add support for month param

### DIFF
--- a/src/Modifiers/InMonth.php
+++ b/src/Modifiers/InMonth.php
@@ -8,14 +8,11 @@ use Statamic\Support\Arr;
 
 class InMonth extends Modifier
 {
-    public function index($value, $params, $context)
+    public function index($value, $params, $context): bool
     {
-        $month = parse_date(
-            Arr::get($context, 'get.month', CarbonImmutable::now()->englishMonth).
-            ' '.
-            Arr::get($context, 'get.year', CarbonImmutable::now()->year)
-        )->month;
+        $month = $params[0] ?? Arr::get($context, 'get.month') ?? CarbonImmutable::now()->englishMonth;
+        $year = $params[1] ?? Arr::get($context, 'get.year') ?? CarbonImmutable::now()->year;
 
-        return CarbonImmutable::parse($value)->month == $month;
+        return CarbonImmutable::parse($value)->month === parse_date("$month $year")->month;
     }
 }

--- a/src/Modifiers/InMonth.php
+++ b/src/Modifiers/InMonth.php
@@ -11,7 +11,7 @@ class InMonth extends Modifier
     public function index($value, $params, $context): bool
     {
         $month = $params[0] ?? Arr::get($context, 'get.month') ?? CarbonImmutable::now()->englishMonth;
-        $year = $params[1] ?? Arr::get($context, 'get.year') ?? CarbonImmutable::now()->year;
+        $year = CarbonImmutable::now()->year;
 
         return CarbonImmutable::parse($value)->month === parse_date("$month $year")->month;
     }

--- a/tests/Modifiers/InMonthTest.php
+++ b/tests/Modifiers/InMonthTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Carbon\CarbonImmutable;
+use Statamic\Modifiers\Modify;
+
+it('returns true when date is in param month', function () {
+    expect(modify(value: '2026-05-15', params: ['May', '2026']))->toBeTrue();
+});
+
+it('returns false when date is not in param month', function () {
+    expect(modify(value: '2026-04-15', params: ['May', '2026']))->toBeFalse();
+});
+
+it('returns true for first day of month', function () {
+    expect(modify(value: '2026-05-01', params: ['May', '2026']))->toBeTrue();
+});
+
+it('returns true for last day of month', function () {
+    expect(modify(value: '2026-05-31', params: ['May', '2026']))->toBeTrue();
+});
+
+it('returns false for day before month', function () {
+    expect(modify(value: '2026-04-30', params: ['May', '2026']))->toBeFalse();
+});
+
+it('returns false for day after month', function () {
+    expect(modify(value: '2026-06-01', params: ['May', '2026']))->toBeFalse();
+});
+
+it('returns true when date matches month from context', function () {
+    expect(modify(value: '2026-05-15', context: ['get' => ['month' => 'May', 'year' => '2026']]))->toBeTrue();
+});
+
+it('returns false when date does not match month from context', function () {
+    expect(modify(value: '2026-04-15', context: ['get' => ['month' => 'May', 'year' => '2026']]))->toBeFalse();
+});
+
+it('param takes precedence over context', function () {
+    expect(modify(value: '2026-06-01', params: ['June', '2026'], context: ['get' => ['month' => 'May', 'year' => '2026']]))->toBeTrue();
+});
+
+it('uses current month when no param or context given', function () {
+    CarbonImmutable::setTestNow('2026-05-15');
+
+    expect(modify(value: '2026-05-01'))->toBeTrue();
+    expect(modify(value: '2026-04-30'))->toBeFalse();
+
+    CarbonImmutable::setTestNow();
+});
+
+
+function modify(string $value, array $params = [], array $context = []): bool
+{
+    return Modify::value($value)->context($context)->inMonth($params)->fetch();
+}

--- a/tests/Modifiers/InMonthTest.php
+++ b/tests/Modifiers/InMonthTest.php
@@ -4,39 +4,39 @@ use Carbon\CarbonImmutable;
 use Statamic\Modifiers\Modify;
 
 it('returns true when date is in param month', function () {
-    expect(modify(value: '2026-05-15', params: ['May', '2026']))->toBeTrue();
+    expect(modify(value: '2026-05-15', params: ['May']))->toBeTrue();
 });
 
 it('returns false when date is not in param month', function () {
-    expect(modify(value: '2026-04-15', params: ['May', '2026']))->toBeFalse();
+    expect(modify(value: '2026-04-15', params: ['May']))->toBeFalse();
 });
 
 it('returns true for first day of month', function () {
-    expect(modify(value: '2026-05-01', params: ['May', '2026']))->toBeTrue();
+    expect(modify(value: '2026-05-01', params: ['May']))->toBeTrue();
 });
 
 it('returns true for last day of month', function () {
-    expect(modify(value: '2026-05-31', params: ['May', '2026']))->toBeTrue();
+    expect(modify(value: '2026-05-31', params: ['May']))->toBeTrue();
 });
 
 it('returns false for day before month', function () {
-    expect(modify(value: '2026-04-30', params: ['May', '2026']))->toBeFalse();
+    expect(modify(value: '2026-04-30', params: ['May']))->toBeFalse();
 });
 
 it('returns false for day after month', function () {
-    expect(modify(value: '2026-06-01', params: ['May', '2026']))->toBeFalse();
+    expect(modify(value: '2026-06-01', params: ['May']))->toBeFalse();
 });
 
 it('returns true when date matches month from context', function () {
-    expect(modify(value: '2026-05-15', context: ['get' => ['month' => 'May', 'year' => '2026']]))->toBeTrue();
+    expect(modify(value: '2026-05-15', context: ['get' => ['month' => 'May']]))->toBeTrue();
 });
 
 it('returns false when date does not match month from context', function () {
-    expect(modify(value: '2026-04-15', context: ['get' => ['month' => 'May', 'year' => '2026']]))->toBeFalse();
+    expect(modify(value: '2026-04-15', context: ['get' => ['month' => 'May']]))->toBeFalse();
 });
 
 it('param takes precedence over context', function () {
-    expect(modify(value: '2026-06-01', params: ['June', '2026'], context: ['get' => ['month' => 'May', 'year' => '2026']]))->toBeTrue();
+    expect(modify(value: '2026-06-01', params: ['June'], context: ['get' => ['month' => 'May']]))->toBeTrue();
 });
 
 it('uses current month when no param or context given', function () {

--- a/tests/Modifiers/InMonthTest.php
+++ b/tests/Modifiers/InMonthTest.php
@@ -4,52 +4,51 @@ use Carbon\CarbonImmutable;
 use Statamic\Modifiers\Modify;
 
 it('returns true when date is in param month', function () {
-    expect(modify(value: '2026-05-15', params: ['May']))->toBeTrue();
+    expect(modifyInMonth(value: '2026-05-15', params: ['May']))->toBeTrue();
 });
 
 it('returns false when date is not in param month', function () {
-    expect(modify(value: '2026-04-15', params: ['May']))->toBeFalse();
+    expect(modifyInMonth(value: '2026-04-15', params: ['May']))->toBeFalse();
 });
 
 it('returns true for first day of month', function () {
-    expect(modify(value: '2026-05-01', params: ['May']))->toBeTrue();
+    expect(modifyInMonth(value: '2026-05-01', params: ['May']))->toBeTrue();
 });
 
 it('returns true for last day of month', function () {
-    expect(modify(value: '2026-05-31', params: ['May']))->toBeTrue();
+    expect(modifyInMonth(value: '2026-05-31', params: ['May']))->toBeTrue();
 });
 
 it('returns false for day before month', function () {
-    expect(modify(value: '2026-04-30', params: ['May']))->toBeFalse();
+    expect(modifyInMonth(value: '2026-04-30', params: ['May']))->toBeFalse();
 });
 
 it('returns false for day after month', function () {
-    expect(modify(value: '2026-06-01', params: ['May']))->toBeFalse();
+    expect(modifyInMonth(value: '2026-06-01', params: ['May']))->toBeFalse();
 });
 
 it('returns true when date matches month from context', function () {
-    expect(modify(value: '2026-05-15', context: ['get' => ['month' => 'May']]))->toBeTrue();
+    expect(modifyInMonth(value: '2026-05-15', context: ['get' => ['month' => 'May']]))->toBeTrue();
 });
 
 it('returns false when date does not match month from context', function () {
-    expect(modify(value: '2026-04-15', context: ['get' => ['month' => 'May']]))->toBeFalse();
+    expect(modifyInMonth(value: '2026-04-15', context: ['get' => ['month' => 'May']]))->toBeFalse();
 });
 
 it('param takes precedence over context', function () {
-    expect(modify(value: '2026-06-01', params: ['June'], context: ['get' => ['month' => 'May']]))->toBeTrue();
+    expect(modifyInMonth(value: '2026-06-01', params: ['June'], context: ['get' => ['month' => 'May']]))->toBeTrue();
 });
 
 it('uses current month when no param or context given', function () {
     CarbonImmutable::setTestNow('2026-05-15');
 
-    expect(modify(value: '2026-05-01'))->toBeTrue();
-    expect(modify(value: '2026-04-30'))->toBeFalse();
+    expect(modifyInMonth(value: '2026-05-01'))->toBeTrue();
+    expect(modifyInMonth(value: '2026-04-30'))->toBeFalse();
 
     CarbonImmutable::setTestNow();
 });
 
-
-function modify(string $value, array $params = [], array $context = []): bool
+function modifyInMonth(string $value, array $params = [], array $context = []): bool
 {
     return Modify::value($value)->context($context)->inMonth($params)->fetch();
 }


### PR DESCRIPTION
This PR
- uses the current year for the comparison (same as before, but simpler in code. we never cared about the year)
- adds support for passing the month as a parameter to the modifier (fallback to get query param)
- adds tests for the `InMonth` modifier