### PR TITLE
Fix `event` filtering on tags

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -193,13 +193,18 @@ sort="desc"
 
 ## Tag Reference
 
+> **Note:** `collection` and `event` are mutually exclusive. Pass `collection` to
+> list occurrences from a whole collection, or `event` to get occurrences for a
+> single entry — not both. Using them together throws an exception. (This does not
+> apply to `events:download_link`, which accepts both.)
+
 ### events:between
 
 Returns events within a date range.
 
 **Parameters:**
-- `collection` (optional, defaults to 'events')
-- `event` (optional) Pass `id` of the event you want occurrences for
+- `collection` (optional, defaults to 'events'; cannot be combined with `event`)
+- `event` (optional) Pass `id` of the event you want occurrences for; cannot be combined with `collection`
 - `from` (optional, defaults to now)
 - `to` (required)
 
@@ -221,8 +226,8 @@ Additional flags:
 Returns events within a future time window.
 
 **Parameters:**
-- `collection` (optional, defaults to 'events')
-- `event` (optional) Pass `id` of the event you want occurrences for
+- `collection` (optional, defaults to 'events'; cannot be combined with `event`)
+- `event` (optional) Pass `id` of the event you want occurrences for; cannot be combined with `collection`
 
 Example:
 
@@ -235,8 +240,8 @@ next="90 days"
 Returns events occurring today.
 
 **Parameters:**
-- `collection` (optional, defaults to 'events')
-- `event` (optional) Pass `id` of the event you want occurrences for
+- `collection` (optional, defaults to 'events'; cannot be combined with `event`)
+- `event` (optional) Pass `id` of the event you want occurrences for; cannot be combined with `collection`
 - `ignore_past` (optional, defaults to 'false')
 
 ### events:upcoming
@@ -245,8 +250,8 @@ Returns the next set of event occurrences.
 
 **Parameters:**
 - `limit` (required)
-- `collection` (optional, defaults to 'events')
-- `event` (optional) Pass `id` of the event you want occurrences for
+- `collection` (optional, defaults to 'events'; cannot be combined with `event`)
+- `event` (optional) Pass `id` of the event you want occurrences for; cannot be combined with `collection`
 - `collapse_multi_days` (optional)
 - `offset` (optional)
 

--- a/src/Entries.php
+++ b/src/Entries.php
@@ -17,10 +17,10 @@ class Entries extends BaseEntries
     protected function query()
     {
         $query = Entry::query()
-            ->whereIn('collection', $this->collections->map->handle()->all())
             ->when(
                 $this->params->get('event'),
-                fn ($query, $id) => $query->whereIn('id', Arr::wrap($id))
+                fn ($query, $id) => $query->whereIn('id', Arr::wrap($id)),
+                fn ($query) => $query->whereIn('collection', $this->collections->map->handle()->all())
             );
 
         $this->querySite($query);

--- a/src/Entries.php
+++ b/src/Entries.php
@@ -3,6 +3,7 @@
 namespace TransformStudios\Events;
 
 use Statamic\Facades\Entry;
+use Statamic\Support\Arr;
 use Statamic\Tags\Collection\Entries as BaseEntries;
 
 class Entries extends BaseEntries
@@ -16,7 +17,11 @@ class Entries extends BaseEntries
     protected function query()
     {
         $query = Entry::query()
-            ->whereIn('collection', $this->collections->map->handle()->all());
+            ->whereIn('collection', $this->collections->map->handle()->all())
+            ->when(
+                $this->params->get('event'),
+                fn ($query, $id) => $query->whereIn('id', Arr::wrap($id))
+            );
 
         $this->querySite($query);
         $this->queryPublished($query);

--- a/src/Events.php
+++ b/src/Events.php
@@ -57,6 +57,11 @@ class Events
 
     public function __construct(Parameters $params)
     {
+        throw_if(
+            $params->has('collection') && $params->has('event'),
+            new Exception('The [collection] and [event] parameters cannot be used together.')
+        );
+
         $this
             ->params($params) // gotta be first cuz some of the later one push to it
             ->collection($params->get('collection', 'events'))

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -30,6 +30,18 @@ beforeEach(function () {
 test('can generate between occurrences of a specific event', function () {
     Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
 
+    Entry::make()
+        ->collection('events')
+        ->slug('single-event')
+        ->id('single-event')
+        ->data([
+            'title' => 'Single Event',
+            'start_date' => Carbon::now()->toDateString(),
+            'start_time' => '11:00',
+            'end_time' => '12:00',
+            'categories' => ['one'],
+        ])->save();
+
     $this->tag
         ->setContext([])
         ->setParameters([

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -55,6 +55,17 @@ test('can generate between occurrences of a specific event', function () {
     expect($occurrences)->toHaveCount(4);
 });
 
+test('throws when both collection and event params are used', function () {
+    $this->tag
+        ->setContext([])
+        ->setParameters([
+            'collection' => 'events',
+            'event' => 'recurring-event',
+        ]);
+
+    $this->tag->between();
+})->throws(\Exception::class, 'The [collection] and [event] parameters cannot be used together.');
+
 test('can generate between occurrences', function () {
     Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
 


### PR DESCRIPTION
## Problem

The `event` parameter on the events tags (`between`, `upcoming`, `today`, `in`, `calendar`) is ignored. Passing `event="some-id"` returns **all** occurrences in the collection instead of only the occurrences for that single entry.

Fixes #173.

## Reason

In the v6 refactor (#168), `Events::entries()` was rewritten to delegate to a new `Entries` query class that only filters by collection:

```php
$query = Entry::query()->whereIn('collection', $this->collections->map->handle()->all());
```

The previous implementation branched on the `event` id to filter `where('id', $id)`. That branch was dropped — the generator still stores the id in `$this->event`, but the field became dead code and is never read by the query. So every tag routed through `Entries` returns the whole collection regardless of `event`.

## Solution

- **Restore the id filter** in `src/Entries.php` using a two-branch `when()` so `event` and `collection` are mutually exclusive, with `event` taking precedence — matching the v5 behavior.
- **Guard against ambiguous usage:** the `Events` generator constructor now throws if both `collection` and `event` are passed. The check runs on the raw params *before* `collection` gets its `'events'` default applied, so it reflects true user intent. This does not affect `events:download_link`, which legitimately accepts both.
- **Tests:** reproduce the regression (a specific `event` now returns 4 occurrences, not 5 when an unrelated entry exists in the collection) and cover the new exception.
- **Docs:** note that `collection` and `event` are mutually exclusive across the query tags.
