### PR TITLE
Performance improvements - skipping already finished events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "statamic/cms": "^6.0"
     },
     "require-dev": {
-        "laravel/pao": "^1.1",
         "orchestra/testbench": "^9.2 || ^10.0",
         "pestphp/pest": "^4.0",
         "spatie/laravel-ray": "^1.35",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "statamic/cms": "^6.0"
     },
     "require-dev": {
+        "laravel/pao": "^1.1",
         "orchestra/testbench": "^9.2 || ^10.0",
         "pestphp/pest": "^4.0",
         "spatie/laravel-ray": "^1.35",

--- a/src/Events.php
+++ b/src/Events.php
@@ -2,6 +2,7 @@
 
 namespace TransformStudios\Events;
 
+use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Exception;
 use Illuminate\Pagination\Paginator;
@@ -181,20 +182,22 @@ class Events
     public function between(string|CarbonInterface $from, string|CarbonInterface $to): EntryCollection|LengthAwarePaginator
     {
         return $this->output(
-            type: fn (Entry $entry) => EventFactory::createFromEntry(event: $entry, collapseMultiDays: $this->collapseMultiDays)->occurrencesBetween(from: $from, to: $to)
+            type: fn (Entry $entry) => EventFactory::createFromEntry(event: $entry, collapseMultiDays: $this->collapseMultiDays)->occurrencesBetween(from: $from, to: $to),
+            from: $from
         );
     }
 
     public function upcoming(int $limit = 1): EntryCollection|LengthAwarePaginator
     {
         return $this->output(
-            type: fn (Entry $entry) => EventFactory::createFromEntry(event: $entry, collapseMultiDays: $this->collapseMultiDays)->nextOccurrences(limit: $limit)
+            type: fn (Entry $entry) => EventFactory::createFromEntry(event: $entry, collapseMultiDays: $this->collapseMultiDays)->nextOccurrences(limit: $limit),
+            from: now()
         );
     }
 
-    private function output(callable $type): EntryCollection|LengthAwarePaginator
+    private function output(callable $type, string|CarbonInterface $from): EntryCollection|LengthAwarePaginator
     {
-        $occurrences = $this->entries()->occurrences(generator: $type);
+        $occurrences = $this->entries()->occurrences(generator: $type, from: $from);
 
         if (! is_null($this->timezone)) {
             $occurrences->transform(function (Entry $occurrence) {
@@ -227,9 +230,10 @@ class Events
         return EventFactory::getTypeClass(event: $occurrence) === MultiDayEvent::class;
     }
 
-    private function occurrences(callable $generator): EntryCollection
+    private function occurrences(callable $generator, string|CarbonInterface $from): EntryCollection
     {
         return $this->entries
+            ->reject(fn (Entry $event) => $this->hasEnded(event: $event, from: $from))
             ->filter(fn (Entry $event) => $this->hasStartDate($event))
             // take each event and generate the occurrences
             ->flatMap(callback: $generator)
@@ -238,6 +242,57 @@ class Events
                 ->contains(fn (Values $dateRow) => $dateRow->date->isSameDay($occurrence->start))
             )->sortBy(callback: fn (Entry $occurrence) => $occurrence->start, descending: $this->sort === 'desc')
             ->values();
+    }
+
+    /*
+        Generating occurrences means augmenting every entry, which is by far the most
+        expensive part of this whole pipeline. Most collections are mostly made up of
+        events that finished long ago, so skip those up front using only raw values -
+        augmenting an entry here just to decide whether to skip it would defeat the point.
+    */
+    private function hasEnded(Entry $event, string|CarbonInterface $from): bool
+    {
+        if (is_null($lastDate = $this->lastPossibleDate($event))) {
+            return false;
+        }
+
+        $from = is_string($from) ? CarbonImmutable::parse($from) : $from;
+
+        // an event's last day runs until midnight in its own timezone, which we don't
+        // know without augmenting, so leave a couple of days of slack to cover any offset
+        return $lastDate->lt($from->copy()->subDays(2)->startOfDay());
+    }
+
+    private function lastPossibleDate(Entry $event): ?CarbonImmutable
+    {
+        $recurrence = $event->get('recurrence');
+
+        if ($recurrence === 'multi_day' || $event->get('multi_day')) {
+            $dates = collect($event->get('days'))->pluck('date')->filter();
+
+            return $dates->isEmpty() ? null : $this->parseDate($dates->max());
+        }
+
+        if (in_array($recurrence, ['daily', 'weekly', 'monthly', 'every'])) {
+            // no end date means it recurs forever
+            return $this->parseDate($event->get('end_date'));
+        }
+
+        return $this->parseDate($event->get('start_date'));
+    }
+
+    // a date we can't read is one we can't rule out, so let it through to the generator
+    private function parseDate($date): ?CarbonImmutable
+    {
+        if (blank($date)) {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($date);
+        } catch (Exception $e) {
+            return null;
+        }
     }
 
     private function hasStartDate(Entry $occurrence): bool

--- a/src/Events.php
+++ b/src/Events.php
@@ -245,10 +245,9 @@ class Events
     }
 
     /*
-        Generating occurrences means augmenting every entry, which is by far the most
-        expensive part of this whole pipeline. Most collections are mostly made up of
-        events that finished long ago, so skip those up front using only raw values -
-        augmenting an entry here just to decide whether to skip it would defeat the point.
+        Generating occurrences means augmenting, which is expenseve, every entry. Most
+        collections are mostly made up of events that finished long ago, so skip those up
+        front using only raw values
     */
     private function hasEnded(Entry $event, string|CarbonInterface $from): bool
     {
@@ -256,11 +255,11 @@ class Events
             return false;
         }
 
-        $from = is_string($from) ? CarbonImmutable::parse($from) : $from;
+        $from = is_string($from) ? CarbonImmutable::parse($from) : $from->toImmutable();
 
         // an event's last day runs until midnight in its own timezone, which we don't
         // know without augmenting, so leave a couple of days of slack to cover any offset
-        return $lastDate->lt($from->copy()->subDays(2)->startOfDay());
+        return $lastDate->lt($from->subDays(2)->startOfDay());
     }
 
     private function lastPossibleDate(Entry $event): ?CarbonImmutable

--- a/src/Events.php
+++ b/src/Events.php
@@ -245,7 +245,7 @@ class Events
     }
 
     /*
-        Generating occurrences means augmenting, which is expenseve, every entry. Most
+        Generating occurrences means augmenting, which is expensive, every entry. Most
         collections are mostly made up of events that finished long ago, so skip those up
         front using only raw values
     */

--- a/tests/SkipsEndedEventsTest.php
+++ b/tests/SkipsEndedEventsTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace TransformStudios\Events\Tests;
+
+use Illuminate\Support\Carbon;
+use Statamic\Facades\Entry;
+use TransformStudios\Events\Events;
+
+beforeEach(function () {
+    Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
+});
+
+test('keeps unbounded recurring event that started years ago', function () {
+    Entry::make()
+        ->collection('events')
+        ->slug('weekly-halaqa')
+        ->data([
+            'title' => 'Weekly Halaqa',
+            'start_date' => now()->subYears(2)->toDateString(),
+            'start_time' => '19:00',
+            'end_time' => '20:00',
+            'recurrence' => 'weekly',
+        ])->save();
+
+    expect(Events::fromCollection('events')->upcoming(1))->toHaveCount(1);
+});
+
+test('keeps annually recurring event that started years ago', function () {
+    Entry::make()
+        ->collection('events')
+        ->slug('annual-fundraiser')
+        ->data([
+            'title' => 'Annual Fundraiser',
+            'start_date' => now()->subYears(3)->toDateString(),
+            'start_time' => '18:00',
+            'end_time' => '21:00',
+            'recurrence' => 'every',
+            'interval' => 1,
+            'period' => 'years',
+        ])->save();
+
+    expect(Events::fromCollection('events')->upcoming(1))->toHaveCount(1);
+});
+
+test('keeps recurring event whose end date is still in the future', function () {
+    Entry::make()
+        ->collection('events')
+        ->slug('term-class')
+        ->data([
+            'title' => 'Term Class',
+            'start_date' => now()->subYear()->toDateString(),
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'recurrence' => 'weekly',
+            'end_date' => now()->addMonths(2)->toDateString(),
+        ])->save();
+
+    expect(Events::fromCollection('events')->upcoming(1))->toHaveCount(1);
+});
+
+test('drops recurring event whose end date has passed', function () {
+    Entry::make()
+        ->collection('events')
+        ->slug('finished-class')
+        ->data([
+            'title' => 'Finished Class',
+            'start_date' => now()->subYears(2)->toDateString(),
+            'start_time' => '09:00',
+            'end_time' => '10:00',
+            'recurrence' => 'weekly',
+            'end_date' => now()->subYear()->toDateString(),
+        ])->save();
+
+    expect(Events::fromCollection('events')->upcoming(1))->toBeEmpty();
+});
+
+test('drops single day event in the past but keeps one in the future', function () {
+    Entry::make()
+        ->collection('events')
+        ->slug('past-lecture')
+        ->data([
+            'title' => 'Past Lecture',
+            'start_date' => now()->subMonth()->toDateString(),
+            'start_time' => '19:00',
+        ])->save();
+
+    Entry::make()
+        ->collection('events')
+        ->slug('future-lecture')
+        ->data([
+            'title' => 'Future Lecture',
+            'start_date' => now()->addMonth()->toDateString(),
+            'start_time' => '19:00',
+        ])->save();
+
+    $occurrences = Events::fromCollection('events')->upcoming(1);
+
+    expect($occurrences)->toHaveCount(1);
+    expect($occurrences->first()->title)->toBe('Future Lecture');
+});
+
+test('drops multi day event whose days have all passed but keeps one with a day still to come', function () {
+    Entry::make()
+        ->collection('events')
+        ->slug('past-conference')
+        ->data([
+            'title' => 'Past Conference',
+            'recurrence' => 'multi_day',
+            'days' => [
+                ['date' => now()->subMonth()->toDateString(), 'start_time' => '09:00', 'end_time' => '17:00'],
+                ['date' => now()->subMonth()->addDay()->toDateString(), 'start_time' => '09:00', 'end_time' => '17:00'],
+            ],
+        ])->save();
+
+    Entry::make()
+        ->collection('events')
+        ->slug('upcoming-conference')
+        ->data([
+            'title' => 'Upcoming Conference',
+            'recurrence' => 'multi_day',
+            'days' => [
+                ['date' => now()->addMonth()->toDateString(), 'start_time' => '09:00', 'end_time' => '17:00'],
+                ['date' => now()->addMonth()->addDay()->toDateString(), 'start_time' => '09:00', 'end_time' => '17:00'],
+            ],
+        ])->save();
+
+    $occurrences = Events::fromCollection('events')->upcoming(5);
+
+    expect($occurrences)->not->toBeEmpty();
+    expect($occurrences->pluck('title')->unique()->all())->toBe(['Upcoming Conference']);
+});
+
+test('keeps a multi day event that is partway through', function () {
+    Entry::make()
+        ->collection('events')
+        ->slug('current-conference')
+        ->data([
+            'title' => 'Current Conference',
+            'recurrence' => 'multi_day',
+            'days' => [
+                ['date' => now()->subDay()->toDateString(), 'start_time' => '09:00', 'end_time' => '17:00'],
+                ['date' => now()->addDay()->toDateString(), 'start_time' => '09:00', 'end_time' => '17:00'],
+            ],
+        ])->save();
+
+    expect(Events::fromCollection('events')->upcoming(5))->not->toBeEmpty();
+});
+
+test('past events are still returned when explicitly querying a past range', function () {
+    Entry::make()
+        ->collection('events')
+        ->slug('last-years-lecture')
+        ->data([
+            'title' => 'Last Years Lecture',
+            'start_date' => now()->subYear()->toDateString(),
+            'start_time' => '19:00',
+            'end_time' => '20:00',
+        ])->save();
+
+    $occurrences = Events::fromCollection('events')->between(
+        now()->subYear()->startOfDay(),
+        now()->subYear()->endOfDay(),
+    );
+
+    expect($occurrences)->toHaveCount(1);
+});


### PR DESCRIPTION
## Summary

`Events::upcoming()`/`between()` fully augment every entry in the collection, then throw almost all of it away. Collections are mostly made up of events that finished long ago, so the vast majority of that work is wasted.

On a real site with **548 events**, 527 had already finished. Generating their occurrences accounted for roughly 90% of the ~1.6s an `upcoming(30)` call took — no SQL involved, it's all Stache augmentation.

## Fix

Reject already-ended events up front, in `occurrences()`, before the generator runs.

The important part is *how* the check is made: it reads **only raw values**. Augmentation is the expensive thing here — measured on one multi-day entry, augmented `$entry->days` costs ~30ms while raw `$entry->get('days')` costs 0ms — so a check that touched augmented values would just relocate the cost instead of removing it.

An event is skipped only when its **last possible date** is known to have passed, which is deliberately not the same as "started in the past":

| type | last possible date |
|---|---|
| non-recurring | `start_date` — the only occurrence |
| recurring | `end_date`; **no `end_date` means it recurs forever** |
| multi-day | the last of its `days` |

So an event that started two years ago and recurs annually is kept, and querying a past range still returns everything it used to. Dates that can't be parsed fall through rather than being excluded, and there's two days of slack because the event's own timezone isn't knowable without augmenting.

## Results

Measured on that 548-event site, `upcoming(30)`:

| | |
|---|---|
| before | ~1646ms |
| after | ~195ms |

Output is **byte-identical** — verified by diffing full dumps against unmodified `main`: 87 rows for `upcoming(30)`, and 1082 rows for a `between()` spanning three years of past events.

## Test plan

- [x] Added `tests/SkipsEndedEventsTest.php` covering the cases this could plausibly get wrong: unbounded recurring events that started years ago, annually recurring events, recurring events with a future vs passed `end_date`, multi-day events that are past/partway through, and past-range `between()` queries.
- [x] Since this is an optimization, those tests pass both before and after — so I checked they actually have teeth by temporarily implementing the naive "`start_date` is in the past" filter instead. **4 of the 8 fail** against it, including every unbounded-recurrence case and the past-range query.
- [x] Full suite green (116 passed).

References https://github.com/transformstudios/zakat.org/issues/2322