### PR TITLE
Add laravel/pao for agent-optimized test output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "statamic/cms": "^6.0"
     },
     "require-dev": {
+        "laravel/pao": "^1.1",
         "orchestra/testbench": "^9.2 || ^10.0",
         "pestphp/pest": "^4.0",
         "spatie/laravel-ray": "^1.35",


### PR DESCRIPTION
Adds `laravel/pao` to `require-dev`. When it detects that an agent is running the suite, it collapses Pest's output to a single JSON line instead of the usual couple of dozen lines of ANSI-formatted output. That's a meaningful token saving when an agent runs the tests repeatedly.