### PR TITLE
Fix recurring event dtstart anchoring to end time instead of start time

### DIFF
--- a/src/Types/RecurringEvent.php
+++ b/src/Types/RecurringEvent.php
@@ -55,7 +55,7 @@ class RecurringEvent extends Event
     protected function rule(bool $useEnd = false): RRuleInterface
     {
         $rule = [
-            'dtstart' => $this->end(),
+            'dtstart' => $useEnd ? $this->end() : $this->start(),
             'freq' => $this->frequency(),
             'interval' => $this->interval(),
         ];

--- a/tests/Tags/EventsTest.php
+++ b/tests/Tags/EventsTest.php
@@ -139,6 +139,41 @@ test('can generate calendar occurrences', function () {
     expect(Arr::get($occurrences, '6.no_results'))->toBeTrue();
 });
 
+test('calendar does not leak a stray day for a daily recurring event with no explicit times', function () {
+    Carbon::setTestNow('aug 1, 2026 10:00');
+
+    Entry::all()->each->delete();
+
+    Entry::make()
+        ->collection('events')
+        ->slug('recurring-event-no-times')
+        ->data([
+            'title' => 'Recurring Event - No Times',
+            'start_date' => '2026-07-11',
+            'end_date' => '2026-08-01',
+            'recurrence' => 'daily',
+            'timezone' => 'America/Los_Angeles',
+        ])->save();
+
+    $this->tag
+        ->setContext([])
+        ->setParameters([
+            'collection' => 'events',
+            'month' => 'August',
+            'year' => 2026,
+        ]);
+
+    $days = collect($this->tag->calendar());
+
+    expect($days->count() % 7)->toBe(0);
+
+    $first = Carbon::parse($days->first()['date']);
+
+    $days->values()->each(
+        fn ($day, $i) => expect($day['date'])->toBe($first->copy()->addDays($i)->toDateString())
+    );
+});
+
 test('can generate in occurrences', function () {
     Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
 


### PR DESCRIPTION
## Summary

`RecurringEvent::rule()` always anchored the RRULE at `$this->end()` (the event's start date with its *end* time), ignoring the `$useEnd` flag that already existed on the method. For a recurring event with no explicit `start_time`/`end_time` set in a timezone offset from the app's default (e.g. `America/Los_Angeles`), this could produce an RRULE occurrence dated one day before the queried `from` boundary.

`Events::calendar()` builds the grid via `makeEmptyDates($from, $to)->merge($occurrences)`. Since the leaked occurrence's date isn't a key in `makeEmptyDates`, `merge()` appended it at the end of the collection instead of dropping it — surfacing as a stray, unwrapped day-cell rendered after the last week row in the calendar view.

## Approach

`rule()` now respects its own `$useEnd` parameter: `dtstart` is `$this->start()` by default, and `$this->end()` only when `$useEnd` is explicitly true (used by `nextOccurrences()`, unchanged).

## Test plan
- [x] Added a test reproducing the bug (`calendar does not leak a stray day for a daily recurring event with no explicit times`) — fails on the old code (43 entries, one out of week-boundary sequence), passes with the fix
- [x] Full test suite passes (120/120)