### PR TITLE
Only pass string addresses to ICS downloads

### DIFF
--- a/src/Types/Event.php
+++ b/src/Types/Event.php
@@ -113,7 +113,7 @@ abstract class Event
             ->startsAt($immutableDate->setTimeFromTimeString($this->startTime()))
             ->endsAt($immutableDate->setTimeFromTimeString($this->endTime()));
 
-        if (! is_null($address = $this->event->address ?? $this->event->get('location'))) {
+        if ($address = $this->icsAddress()) {
             $iCalEvent->address($address);
         }
 
@@ -146,11 +146,20 @@ abstract class Event
             return $link;
         }
 
-        if (is_null($location = $this->event->location)) {
+        $location = $this->event->get('location');
+
+        if (! is_string($location)) {
             return null;
         }
 
         return Str::isUrl($location) ? $location : null;
+    }
+
+    protected function icsAddress(): ?string
+    {
+        $address = $this->event->address ?? $this->event->get('location');
+
+        return is_string($address) && $address !== '' ? $address : null;
     }
 
     protected function supplement(CarbonInterface $date): ?Entry

--- a/src/Types/MultiDayEvent.php
+++ b/src/Types/MultiDayEvent.php
@@ -64,7 +64,7 @@ class MultiDayEvent extends Event
             ->startsAt($immutableDate->setTimeFromTimeString($day->start()))
             ->endsAt($immutableDate->setTimeFromTimeString($day->end()));
 
-        if (! is_null($address = $this->event->address ?? $this->event->location)) {
+        if ($address = $this->icsAddress()) {
             $iCalEvent->address($address);
         }
 

--- a/src/Types/RecurringEvent.php
+++ b/src/Types/RecurringEvent.php
@@ -74,22 +74,22 @@ class RecurringEvent extends Event
     private function frequency(): int
     {
         return match ($this->recurrence->value()) {
-            'daily' => RRule::DAILY,
-            'weekly' => RRule::WEEKLY,
-            'monthly' => RRule::MONTHLY,
-            'yearly' => RRule::YEARLY,
+            'daily' => Rrule::DAILY,
+            'weekly' => Rrule::WEEKLY,
+            'monthly' => Rrule::MONTHLY,
+            'yearly' => Rrule::YEARLY,
             'every' => $this->periodToFrequency(),
-            default => RRule::DAILY
+            default => Rrule::DAILY
         };
     }
 
     private function frequencyToRecurrence(): RecurrenceFrequency
     {
         return match ($this->frequency()) {
-            RRule::DAILY => RecurrenceFrequency::Daily,
-            RRule::WEEKLY => RecurrenceFrequency::Weekly,
-            RRule::MONTHLY => RecurrenceFrequency::Monthly,
-            RRule::YEARLY => RecurrenceFrequency::Yearly,
+            Rrule::DAILY => RecurrenceFrequency::Daily,
+            Rrule::WEEKLY => RecurrenceFrequency::Weekly,
+            Rrule::MONTHLY => RecurrenceFrequency::Monthly,
+            Rrule::YEARLY => RecurrenceFrequency::Yearly,
             default => RecurrenceFrequency::Daily
         };
     }
@@ -97,11 +97,11 @@ class RecurringEvent extends Event
     private function periodToFrequency(): int
     {
         return match ($this->period->value()) {
-            'days' => RRule::DAILY,
-            'weeks' => RRule::WEEKLY,
-            'months' => RRule::MONTHLY,
-            'years' => RRule::YEARLY,
-            default => RRule::DAILY
+            'days' => Rrule::DAILY,
+            'weeks' => Rrule::WEEKLY,
+            'months' => Rrule::MONTHLY,
+            'years' => Rrule::YEARLY,
+            default => Rrule::DAILY
         };
     }
 

--- a/src/Types/RecurringEvent.php
+++ b/src/Types/RecurringEvent.php
@@ -33,7 +33,7 @@ class RecurringEvent extends Event
             ->endsAt($this->end())
             ->rrule($this->spatieRule());
 
-        if (! is_null($address = $this->event->address ?? $this->event->location)) {
+        if ($address = $this->icsAddress()) {
             $iCalEvent->address($address);
         }
 
@@ -74,22 +74,22 @@ class RecurringEvent extends Event
     private function frequency(): int
     {
         return match ($this->recurrence->value()) {
-            'daily' => Rrule::DAILY,
-            'weekly' => Rrule::WEEKLY,
-            'monthly' => Rrule::MONTHLY,
-            'yearly' => Rrule::YEARLY,
+            'daily' => RRule::DAILY,
+            'weekly' => RRule::WEEKLY,
+            'monthly' => RRule::MONTHLY,
+            'yearly' => RRule::YEARLY,
             'every' => $this->periodToFrequency(),
-            default => Rrule::DAILY
+            default => RRule::DAILY
         };
     }
 
     private function frequencyToRecurrence(): RecurrenceFrequency
     {
         return match ($this->frequency()) {
-            Rrule::DAILY => RecurrenceFrequency::Daily,
-            Rrule::WEEKLY => RecurrenceFrequency::Weekly,
-            Rrule::MONTHLY => RecurrenceFrequency::Monthly,
-            Rrule::YEARLY => RecurrenceFrequency::Yearly,
+            RRule::DAILY => RecurrenceFrequency::Daily,
+            RRule::WEEKLY => RecurrenceFrequency::Weekly,
+            RRule::MONTHLY => RecurrenceFrequency::Monthly,
+            RRule::YEARLY => RecurrenceFrequency::Yearly,
             default => RecurrenceFrequency::Daily
         };
     }
@@ -97,11 +97,11 @@ class RecurringEvent extends Event
     private function periodToFrequency(): int
     {
         return match ($this->period->value()) {
-            'days' => Rrule::DAILY,
-            'weeks' => Rrule::WEEKLY,
-            'months' => Rrule::MONTHLY,
-            'years' => Rrule::YEARLY,
-            default => Rrule::DAILY
+            'days' => RRule::DAILY,
+            'weeks' => RRule::WEEKLY,
+            'months' => RRule::MONTHLY,
+            'years' => RRule::YEARLY,
+            default => RRule::DAILY
         };
     }
 

--- a/tests/Http/Contollers/IcsControllerTest.php
+++ b/tests/Http/Contollers/IcsControllerTest.php
@@ -196,3 +196,117 @@ test('throws 404 error when date is invalid', function () {
         'event' => 'the-id',
     ]))->assertStatus(404);
 });
+
+test('can create ics when location is a group without address', function () {
+    Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
+
+    Entry::make()
+        ->collection('events')
+        ->slug('grouped-location-event')
+        ->id('the-grouped-location-id')
+        ->data([
+            'title' => 'Grouped Location Event',
+            'start_date' => Carbon::now()->toDateString(),
+            'start_time' => '11:00',
+            'end_time' => '12:00',
+            'location' => [
+                'details' => 'Virtual',
+                'coordinates' => [
+                    'latitude' => 40,
+                    'longitude' => 50,
+                ],
+            ],
+            'description' => 'The description',
+        ])->save();
+
+    $response = $this->get(route('statamic.events.ics.show', [
+        'date' => now()->toDateString(),
+        'event' => 'the-grouped-location-id',
+    ]))->assertDownload('grouped-location-event.ics');
+
+    $content = $response->streamedContent();
+
+    $this->assertStringNotContainsString('LOCATION:', $content);
+    $this->assertStringContainsString('DESCRIPTION:The description', $content);
+});
+
+test('falls back to string location when address is missing', function () {
+    Carbon::setTestNow(now()->setTimeFromTimeString('10:00'));
+
+    Entry::make()
+        ->collection('events')
+        ->slug('location-fallback-event')
+        ->id('the-location-fallback-id')
+        ->data([
+            'title' => 'Location Fallback Event',
+            'start_date' => Carbon::now()->toDateString(),
+            'start_time' => '11:00',
+            'end_time' => '12:00',
+            'location' => 'The Location',
+            'description' => 'The description',
+        ])->save();
+
+    $response = $this->get(route('statamic.events.ics.show', [
+        'date' => now()->toDateString(),
+        'event' => 'the-location-fallback-id',
+    ]))->assertDownload('location-fallback-event.ics');
+
+    $this->assertStringContainsString('LOCATION:The Location', $response->streamedContent());
+});
+
+test('can create recurring ics when location is a group without address', function () {
+    Carbon::setTestNow(now()->addDay()->setTimeFromTimeString('10:00'));
+
+    Entry::make()
+        ->collection('events')
+        ->slug('grouped-recurring-event')
+        ->id('the-grouped-recurring-id')
+        ->data([
+            'title' => 'Grouped Recurring Event',
+            'start_date' => Carbon::now()->toDateString(),
+            'start_time' => '11:00',
+            'end_time' => '12:00',
+            'recurrence' => 'weekly',
+            'location' => [
+                'details' => 'Virtual',
+            ],
+            'description' => 'The description',
+        ])->save();
+
+    $response = $this->get(route('statamic.events.ics.show', [
+        'event' => 'the-grouped-recurring-id',
+    ]))->assertDownload('grouped-recurring-event.ics');
+
+    $this->assertStringNotContainsString('LOCATION:', $response->streamedContent());
+});
+
+test('can create multi-day ics when location is a group without address', function () {
+    Carbon::setTestNow(now());
+
+    Entry::make()
+        ->slug('grouped-multi-day-event')
+        ->collection('events')
+        ->id('the-grouped-multi-day-id')
+        ->data([
+            'title' => 'Grouped Multi-day Event',
+            'multi_day' => true,
+            'location' => [
+                'details' => 'Virtual',
+            ],
+            'description' => 'The description',
+            'days' => [
+                [
+                    'date' => now()->toDateString(),
+                    'start_time' => '19:00',
+                    'end_time' => '21:00',
+                ],
+            ],
+        ])->save();
+
+    $response = $this->get(route('statamic.events.ics.show', [
+        'date' => now()->toDateString(),
+        'event' => 'the-grouped-multi-day-id',
+    ]))->assertDownload('grouped-multi-day-event.ics');
+
+    $this->assertStringNotContainsString('LOCATION:', $response->streamedContent());
+});


### PR DESCRIPTION
## Summary
- Fixes ICS 500s when `location` is a group/array (Prime location fieldset, empty `location: {}`, or coords-only) instead of a string.
- Adds `icsAddress()` so Spatie only receives a non-empty string; keeps the `address` then string-`location` fallback.
- Closes #183. Reported from [passivehouseaccelerator.com#310](https://github.com/transformstudios/passivehouseaccelerator.com/issues/310).
- temp fix until https://github.com/transformstudios/zakat.org/issues/2329 is implemented

## Test plan
- [x] ICS download with string `address` still writes `LOCATION:`
- [x] ICS download with string `location` and no `address` still writes `LOCATION:`
- [x] ICS download with group/array `location` and no `address` returns 200 and omits `LOCATION:` (single, recurring, multi-day)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized ICS export fix with type guards and regression tests; no auth, persistence, or API contract changes beyond avoiding errors on array locations.
> 
> **Overview**
> Fixes ICS **500 errors** when `location` is a group/array (e.g. Prime location fieldset, empty `location: {}`, or coords-only) instead of a plain string.
> 
> Introduces **`icsAddress()`** on the base `Event` type so Spatie’s iCal builder only receives a **non-empty string**—still preferring `address`, then falling back to string `location`. Single-day, recurring, and multi-day ICS builders all route through this helper instead of passing raw `location` values.
> 
> **`eventUrl()`** is aligned to read `location` via `get('location')` and skip non-string values before URL checks.
> 
> New controller tests cover grouped `location` without `LOCATION:` in the file, string `location` fallback, and the same cases for recurring and multi-day exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf61c0c5b5dda003b2ea8499700b5d9537c5d411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->