### PR TITLE
Drop unused spatie/calendar-links dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require": {
         "php": "^8.3",
         "rlanvin/php-rrule": "^2.3.1",
-        "spatie/calendar-links": "^1.0",
         "spatie/icalendar-generator": "^3.2.1",
         "statamic/cms": "^6.0"
     },


### PR DESCRIPTION
Closes #188.

@steveparks is correct — `spatie/calendar-links` is no longer used anywhere in this addon. All calendar/ICS generation goes through `spatie/icalendar-generator`.

### Verification

A search across the whole repo (`src/`, `tests/`, `resources/`, `routes/`, docs, templates) for `CalendarLinks` / `calendar-links` returns exactly one hit: the `require` entry in `composer.json` itself. The only Spatie imports remaining are:

```
src/Http/Controllers/IcsController.php:12  Spatie\IcalendarGenerator\Components\Calendar
src/Http/Controllers/IcsController.php:13  Spatie\IcalendarGenerator\Components\Event
src/Types/RecurringEvent.php:9-11          Spatie\IcalendarGenerator\{Components\Event, Enums\RecurrenceFrequency, ValueObjects\RRule}
src/Types/MultiDayEvent.php:11             Spatie\IcalendarGenerator\Components\Event
src/Types/Event.php:12                     Spatie\IcalendarGenerator\Components\Event
src/Day.php:6                              Spatie\IcalendarGenerator\Components\Event
```

### Change

Removes the `"spatie/calendar-links": "^1.0"` line from `composer.json`. Nothing else needed — no imports, no config, no docs referenced it.

This is purely a dependency cleanup with no behaviour change, but it does unconstrain consumers' dependency graphs (the `^1.0` pin was holding back anyone who wanted a newer `calendar-links` for their own use).

Note: the branch name doesn't match the `pr-labeler.yml` patterns, so you may want to add the `chore` label manually for release-drafter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xw4jZB7SwYKsbtdJ3yyG7e)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only cleanup with no runtime or API changes.
> 
> **Overview**
> Removes unused `spatie/calendar-links` from `composer.json`. ICS generation already uses `spatie/icalendar-generator` only; no code, config, or docs referenced the dropped package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62af124e43c78614b58885c156454d5b4de3476a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->