### PR TITLE
Include localized events that inherit dates from origin

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -264,20 +264,21 @@ class Events
 
     private function lastPossibleDate(Entry $event): ?CarbonImmutable
     {
-        $recurrence = $event->get('recurrence');
+        // value() inherits from the origin so localized stubs still resolve dates
+        $recurrence = $event->value('recurrence');
 
-        if ($recurrence === 'multi_day' || $event->get('multi_day')) {
-            $dates = collect($event->get('days'))->pluck('date')->filter();
+        if ($recurrence === 'multi_day' || $event->value('multi_day')) {
+            $dates = collect($event->value('days'))->pluck('date')->filter();
 
             return $dates->isEmpty() ? null : $this->parseDate($dates->max());
         }
 
         if (in_array($recurrence, ['daily', 'weekly', 'monthly', 'every'])) {
             // no end date means it recurs forever
-            return $this->parseDate($event->get('end_date'));
+            return $this->parseDate($event->value('end_date'));
         }
 
-        return $this->parseDate($event->get('start_date'));
+        return $this->parseDate($event->value('start_date'));
     }
 
     // a date we can't read is one we can't rule out, so let it through to the generator
@@ -306,7 +307,7 @@ class Events
             }
         }
 
-        return $occurrence->has('start_date');
+        return filled($occurrence->value('start_date'));
     }
 
     private function paginate(EntryCollection $occurrences): LengthAwarePaginator

--- a/tests/LocalizedEventsTest.php
+++ b/tests/LocalizedEventsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace TransformStudios\Events\Tests;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Carbon;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
+use TransformStudios\Events\Events;
+
+beforeEach(function () {
+    Site::setSites([
+        'default' => ['name' => 'English', 'locale' => 'en_US', 'url' => '/'],
+        'ar' => ['name' => 'Arabic', 'locale' => 'ar', 'url' => '/ar/'],
+    ]);
+
+    $this->collection->sites(['default', 'ar'])->save();
+
+    Carbon::setTestNow('2026-08-15 10:00:00');
+});
+
+test('includes localized events that inherit start_date from the origin', function () {
+    $origin = Entry::make()
+        ->collection('events')
+        ->locale('default')
+        ->slug('art-collective')
+        ->data([
+            'title' => 'Collective Art Activities',
+            'start_date' => '2026-08-31',
+            'start_time' => '14:00',
+            'end_time' => '16:00',
+            'timezone' => 'America/Los_Angeles',
+        ]);
+    $origin->save();
+
+    $localized = $origin->makeLocalization('ar');
+    $localized->set('title', 'أنشطة فنية جماعية');
+    $localized->save();
+
+    expect($localized->has('start_date'))->toBeFalse()
+        ->and($localized->get('start_date'))->toBeNull()
+        ->and($localized->value('start_date'))->toBe('2026-08-31');
+
+    Site::setCurrent('ar');
+
+    $occurrences = Events::fromCollection('events')
+        ->site('ar')
+        ->between(
+            CarbonImmutable::parse('2026-08-01')->startOfDay(),
+            CarbonImmutable::parse('2026-08-31')->endOfDay()
+        );
+
+    expect($occurrences)->toHaveCount(1)
+        ->and($occurrences->first()->title)->toBe('أنشطة فنية جماعية')
+        ->and($occurrences->first()->start->toDateString())->toBe('2026-08-31');
+});
+
+test('still drops localized events whose origin start date is in the past', function () {
+    $origin = Entry::make()
+        ->collection('events')
+        ->locale('default')
+        ->slug('past-event')
+        ->data([
+            'title' => 'Past Event',
+            'start_date' => '2026-07-01',
+            'start_time' => '14:00',
+        ]);
+    $origin->save();
+
+    $localized = $origin->makeLocalization('ar');
+    $localized->set('title', 'حدث سابق');
+    $localized->save();
+
+    Site::setCurrent('ar');
+
+    expect(
+        Events::fromCollection('events')->site('ar')->upcoming(1)
+    )->toBeEmpty();
+});


### PR DESCRIPTION
## Summary
- Localized event stubs (e.g. Arabic copy with only a title) inherit `start_date` via `value()` but not `get()`/`has()`.
- `hasStartDate` / `lastPossibleDate` used the raw getters, so those entries never produced calendar occurrences.
- Use `value()` so origin dates resolve; still skip truly dateless entries and past events.

## Test plan
- [ ] Multi-site: localize an event without copying dates; calendar on the localized site shows the occurrence
- [ ] Past localized event still omitted from upcoming/between
- [ ] Existing single-site event queries unchanged